### PR TITLE
Update test dependencies and remove redundant references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,14 +35,13 @@ jobs:
           echo "create=$create" | tee -a "$GITHUB_OUTPUT"
 
       - if: ${{ fromJSON(steps.tag.outputs.create) }}
+        name: Set up Go
+        uses: actions/setup-go@v5
+        with: { cache: true }
+
+      - if: ${{ fromJSON(steps.tag.outputs.create) }}
         name: Install nats-server
-        run: |
-          branch=$(curl https://api.mtmk.dev/gh/v1/releases/tag/nats-io/nats-server/latest)
-          for i in 1 2 3
-          do
-            curl -sf https://binaries.nats.dev/nats-io/nats-server/v2@$branch | PREFIX=. sh && break || sleep 30
-          done
-          sudo mv nats-server /usr/local/bin
+        run: go install github.com/nats-io/nats-server/v2@latest
 
       - if: ${{ fromJSON(steps.tag.outputs.create) }}
         name: Check nats-server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: 'v2.9'
+          - branch: 'v2.10'
+          - branch: 'v2.11'
           - branch: 'latest'
           - branch: 'main'
     runs-on: ubuntu-latest
@@ -22,14 +23,12 @@ jobs:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with: { cache: true }
+
       - name: Install nats-server
-        run: |
-          branch=$(curl https://api.mtmk.dev/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
-          for i in 1 2 3
-          do
-            curl -sf https://binaries.nats.dev/nats-io/nats-server/v2@$branch | PREFIX=. sh && break || sleep 30
-          done
-          sudo mv nats-server /usr/local/bin
+        run: go install github.com/nats-io/nats-server/v2@${{ matrix.config.branch }}
 
       - name: Check nats-server
         run: nats-server -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: 'v2.9'
+          - branch: 'v2.10'
+          - branch: 'v2.11'
           - branch: 'latest'
           - branch: 'main'
     runs-on: windows-latest
@@ -70,6 +71,16 @@ jobs:
       NUGET_XMLDOC_MODE: skip
       MSYS_NO_PATHCONV: 1
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with: { cache: true }
+
+      - name: Install nats-server
+        run: go install github.com/nats-io/nats-server/v2@${{ matrix.config.branch }}
+
+      - name: Check nats-server
+        run: nats-server -v
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -81,17 +92,6 @@ jobs:
           dotnet-version: |
             8.x
             9.x
-
-      - name: Get nats-server
-        shell: bash
-        run: |
-          mkdir tools-nats-server && cd tools-nats-server
-          branch=$(curl https://api.mtmk.dev/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
-          curl -sL -o nats-server.exe "https://binaries.nats.dev/binary/github.com/nats-io/nats-server/v2?os=windows&arch=amd64&version=$branch"
-          cygpath -w "$(pwd)" | tee -a "$GITHUB_PATH"
-
-      - name: Check nats-server
-        run: nats-server -v
 
       - name: Build
         run: dotnet build -c Release

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -76,9 +76,4 @@
     <PackageReference Include="IndexRange" Version="1.0.3"/>
   </ItemGroup>
 
-  <!--  Dependencies for net6.0 and net8.0 only -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="System.Text.Json" Version="8.0.5"/>
-  </ItemGroup>
-
 </Project>

--- a/tests/Synadia.Orbit.JetStream.Extensions.Test/Synadia.Orbit.JetStream.Extensions.Test.csproj
+++ b/tests/Synadia.Orbit.JetStream.Extensions.Test/Synadia.Orbit.JetStream.Extensions.Test.csproj
@@ -12,10 +12,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-    <PackageReference Include="xunit.v3" Version="1.0.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="xunit.v3" Version="3.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Synadia.Orbit.JetStream.Extensions.Test/Synadia.Orbit.JetStream.Extensions.Test.csproj
+++ b/tests/Synadia.Orbit.JetStream.Extensions.Test/Synadia.Orbit.JetStream.Extensions.Test.csproj
@@ -9,6 +9,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <Version>1.0.0</Version>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Synadia.Orbit.JetStream.Publisher.Test/Synadia.Orbit.JetStream.Publisher.Test.csproj
+++ b/tests/Synadia.Orbit.JetStream.Publisher.Test/Synadia.Orbit.JetStream.Publisher.Test.csproj
@@ -9,6 +9,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <Version>1.0.0</Version>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Synadia.Orbit.JetStream.Publisher.Test/Synadia.Orbit.JetStream.Publisher.Test.csproj
+++ b/tests/Synadia.Orbit.JetStream.Publisher.Test/Synadia.Orbit.JetStream.Publisher.Test.csproj
@@ -12,10 +12,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-    <PackageReference Include="xunit.v3" Version="1.0.1"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="xunit.v3" Version="3.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
* Upgraded testing-related dependencies (`coverlet.collector`, `Microsoft.NET.Test.Sdk`, `xunit.v3`, and `xunit.runner.visualstudio`) to their latest versions.
* Removed framework-specific `System.Text.Json` dependency configuration. This was done for a CVE but the fix has been included in the SDK for some time now.
* Simplify nats-server installation in workflows and update test branches
* Replaced custom installation script with `go install` for nats-server in release and test workflows, reducing complexity.
* Added new test branches `v2.10` and `v2.11` for expanded version coverage.