### PR TITLE
Upgrade NATS .NET 2.7.2 and bump versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,10 +131,14 @@ jobs:
         run: |
           TAG="${{ matrix.tag }}"
           VERSION="${TAG#*/v}"
+          PRERELEASE_FLAG=""
+          if [[ "$VERSION" == *-* ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "GitHub release for tag '$TAG' already exists; skipping creation."
           else
-            gh release create "$TAG" --title "Synadia.Orbit.${{ matrix.pkg }} v${VERSION}" --notes ""
+            gh release create "$TAG" --title "Synadia.Orbit.${{ matrix.pkg }} v${VERSION}" --notes "" $PRERELEASE_FLAG
           fi
 
       - name: Tag (dry-run)
@@ -145,4 +149,10 @@ jobs:
       - name: Create GitHub Release (dry-run)
         if: ${{ env.DRY_RUN == 'true' }}
         run: |
-          echo "Dry-run: would create GitHub release for ${{ matrix.tag }}"
+          TAG="${{ matrix.tag }}"
+          VERSION="${TAG#*/v}"
+          if [[ "$VERSION" == *-* ]]; then
+            echo "Dry-run: would create GitHub pre-release for $TAG"
+          else
+            echo "Dry-run: would create GitHub release for $TAG"
+          fi

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <NatsVersion>2.7.2-preview.1</NatsVersion>
+    <NatsVersion>2.7.2</NatsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="NATS.Net" Version="$(NatsVersion)" />

--- a/src/Synadia.Orbit.Core.Extensions/version.txt
+++ b/src/Synadia.Orbit.Core.Extensions/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.1
+1.0.0-preview.2

--- a/src/Synadia.Orbit.Counters/version.txt
+++ b/src/Synadia.Orbit.Counters/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.1
+1.0.0-preview.2

--- a/src/Synadia.Orbit.JetStream.Extensions/version.txt
+++ b/src/Synadia.Orbit.JetStream.Extensions/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.2
+1.0.0-preview.3

--- a/src/Synadia.Orbit.JetStream.Publisher/version.txt
+++ b/src/Synadia.Orbit.JetStream.Publisher/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.1
+1.0.0-preview.2

--- a/src/Synadia.Orbit.KeyValueStore.Extensions/version.txt
+++ b/src/Synadia.Orbit.KeyValueStore.Extensions/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.1
+1.0.0-preview.2

--- a/src/Synadia.Orbit.NatsCli.Plugin/version.txt
+++ b/src/Synadia.Orbit.NatsCli.Plugin/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.1
+1.0.0-preview.2

--- a/src/Synadia.Orbit.NatsContext/version.txt
+++ b/src/Synadia.Orbit.NatsContext/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.1
+1.0.0-preview.2

--- a/src/Synadia.Orbit.PCGroups/version.txt
+++ b/src/Synadia.Orbit.PCGroups/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.2
+1.0.0-preview.3


### PR DESCRIPTION
Incremented project versions to the next preview release. Updated `release.yml` to add support for pre-release tags using `--prerelease` flag, ensuring compatibility with pre-release workflows. Adjusted dry-run behavior to reflect release type. Upgraded NATS dependency to stable version 2.7.2.

This release will also include the new scheduled message updates in JetStream Extensions package.