### PR TITLE
Support updating PCGroup filters dynamically

### DIFF
--- a/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticConfig.cs
+++ b/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticConfig.cs
@@ -17,16 +17,10 @@ public sealed record NatsPcgElasticConfig
     public required uint MaxMembers { get; init; }
 
     /// <summary>
-    /// Gets the subject filter for the consumer group.
+    /// Gets the partitioning filters, each pairing a subject filter with its wildcard positions for partitioning.
     /// </summary>
-    [JsonPropertyName("filter")]
-    public required string Filter { get; init; }
-
-    /// <summary>
-    /// Gets the wildcard positions used for partitioning (1-indexed).
-    /// </summary>
-    [JsonPropertyName("partitioning_wildcards")]
-    public required int[] PartitioningWildcards { get; init; }
+    [JsonPropertyName("partitioning_filters")]
+    public required NatsPcgPartitioningFilter[] PartitioningFilters { get; init; }
 
     /// <summary>
     /// Gets the optional maximum number of buffered messages.

--- a/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticConsumeContext.cs
+++ b/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticConsumeContext.cs
@@ -260,11 +260,7 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
             config = _config;
         }
 
-        string[] filters = NatsPcgPartitionDistributor.GeneratePartitionFilters(
-            config.Members,
-            config.MaxMembers,
-            config.MemberMappings,
-            _memberName);
+        string[] filters = GenerateFiltersForMember(config, _memberName);
 
         _currentFilters = filters;
 
@@ -313,11 +309,7 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
         }
 
         // Recalculate filters
-        string[] filters = NatsPcgPartitionDistributor.GeneratePartitionFilters(
-            config.Members,
-            config.MaxMembers,
-            config.MemberMappings,
-            _memberName);
+        string[] filters = GenerateFiltersForMember(config, _memberName);
 
         // Only recreate if filters changed
         if (FiltersEqual(filters, _currentFilters))
@@ -345,6 +337,34 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
         };
 
         _consumer = await _js.CreateOrUpdateConsumerAsync(workQueueStreamName, consumerConfig, _cts.Token).ConfigureAwait(false);
+    }
+
+    private static string[] GenerateFiltersForMember(NatsPcgElasticConfig config, string memberName)
+    {
+        var allFilters = new List<string>();
+        if (config.PartitioningFilters.Length > 0)
+        {
+            foreach (var pf in config.PartitioningFilters)
+            {
+                allFilters.AddRange(NatsPcgPartitionDistributor.GeneratePartitionFilters(
+                    config.Members,
+                    config.MaxMembers,
+                    config.MemberMappings,
+                    memberName,
+                    pf.Filter));
+            }
+        }
+        else
+        {
+            allFilters.AddRange(NatsPcgPartitionDistributor.GeneratePartitionFilters(
+                config.Members,
+                config.MaxMembers,
+                config.MemberMappings,
+                memberName,
+                ">"));
+        }
+
+        return allFilters.ToArray();
     }
 
     private async Task WatchConfigLoopAsync()

--- a/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticExtensions.cs
+++ b/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticExtensions.cs
@@ -25,8 +25,7 @@ public static class NatsPcgElasticExtensions
     /// <param name="streamName">Name of the source stream.</param>
     /// <param name="consumerGroupName">Name of the consumer group.</param>
     /// <param name="maxNumMembers">Maximum number of members (also the number of partitions).</param>
-    /// <param name="filter">Subject filter for the consumer group.</param>
-    /// <param name="partitioningWildcards">Wildcard positions for partitioning (1-indexed).</param>
+    /// <param name="partitioningFilters">Partitioning filters, each pairing a subject filter with wildcard positions.</param>
     /// <param name="maxBufferedMessages">Optional maximum number of buffered messages.</param>
     /// <param name="maxBufferedBytes">Optional maximum bytes of buffered messages.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -36,19 +35,17 @@ public static class NatsPcgElasticExtensions
         string streamName,
         string consumerGroupName,
         uint maxNumMembers,
-        string filter,
-        int[] partitioningWildcards,
+        NatsPcgPartitioningFilter[] partitioningFilters,
         long? maxBufferedMessages = null,
         long? maxBufferedBytes = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateConfig(maxNumMembers, filter, partitioningWildcards);
+        ValidateConfig(maxNumMembers, partitioningFilters);
 
         var config = new NatsPcgElasticConfig
         {
             MaxMembers = maxNumMembers,
-            Filter = filter,
-            PartitioningWildcards = partitioningWildcards,
+            PartitioningFilters = partitioningFilters,
             MaxBufferedMsgs = maxBufferedMessages,
             MaxBufferedBytes = maxBufferedBytes,
         };
@@ -461,11 +458,30 @@ public static class NatsPcgElasticExtensions
     /// <returns>Array of partition filters.</returns>
     public static string[] GetPcgElasticPartitionFilters(this NatsPcgElasticConfig config, string memberName)
     {
-        return NatsPcgPartitionDistributor.GeneratePartitionFilters(
-            config.Members,
-            config.MaxMembers,
-            config.MemberMappings,
-            memberName);
+        var filters = new List<string>();
+        if (config.PartitioningFilters.Length > 0)
+        {
+            foreach (var pf in config.PartitioningFilters)
+            {
+                filters.AddRange(NatsPcgPartitionDistributor.GeneratePartitionFilters(
+                    config.Members,
+                    config.MaxMembers,
+                    config.MemberMappings,
+                    memberName,
+                    pf.Filter));
+            }
+        }
+        else
+        {
+            filters.AddRange(NatsPcgPartitionDistributor.GeneratePartitionFilters(
+                config.Members,
+                config.MaxMembers,
+                config.MemberMappings,
+                memberName,
+                ">"));
+        }
+
+        return filters.ToArray();
     }
 
     /// <summary>
@@ -491,7 +507,7 @@ public static class NatsPcgElasticExtensions
     }
 
     // ReSharper disable ParameterOnlyUsedForPreconditionCheck.Local
-    private static void ValidateConfig(uint maxNumMembers, string filter, int[] partitioningWildcards)
+    private static void ValidateConfig(uint maxNumMembers, NatsPcgPartitioningFilter[] partitioningFilters)
     {
         // ReSharper restore ParameterOnlyUsedForPreconditionCheck.Local
         if (maxNumMembers == 0)
@@ -499,7 +515,7 @@ public static class NatsPcgElasticExtensions
             throw new NatsPcgConfigurationException("maxNumMembers must be greater than 0");
         }
 
-        NatsPcgMemberMappingValidator.ValidateFilterAndWildcards(filter, partitioningWildcards);
+        NatsPcgMemberMappingValidator.ValidatePartitioningFilters(partitioningFilters);
     }
 
     private static async Task CreateWorkQueueStreamAsync(
@@ -511,37 +527,26 @@ public static class NatsPcgElasticExtensions
     {
         string workQueueStreamName = GetWorkQueueStreamName(streamName, consumerGroupName);
 
-        // Build subject transform: add partition prefix based on wildcards
-        // Transform syntax: {{Partition(numPartitions, wildcardIndexes...)}}
-        // Replace * wildcards with {{wildcard(N)}} in the filter
-        string wildcardStr = string.Join(",", config.PartitioningWildcards);
-        var filterTokens = config.Filter.Split('.');
-        int wildcardIndex = 1;
-        for (int i = 0; i < filterTokens.Length; i++)
+        var subjectTransforms = new List<SubjectTransform>();
+        if (config.PartitioningFilters.Length > 0)
         {
-            if (filterTokens[i] == "*")
+            foreach (var pf in config.PartitioningFilters)
             {
-                filterTokens[i] = $"{{{{wildcard({wildcardIndex})}}}}";
-                wildcardIndex++;
+                subjectTransforms.Add(BuildSubjectTransform(pf, config.MaxMembers));
             }
         }
-
-        string destFromFilter = string.Join(".", filterTokens);
-        string subjectTransform = $"{{{{Partition({config.MaxMembers},{wildcardStr})}}}}.{destFromFilter}";
+        else
+        {
+            var defaultFilter = new NatsPcgPartitioningFilter(">", Array.Empty<int>());
+            subjectTransforms.Add(BuildSubjectTransform(defaultFilter, config.MaxMembers));
+        }
 
         var sources = new List<StreamSource>
         {
             new()
             {
                 Name = streamName,
-                SubjectTransforms = new List<SubjectTransform>
-                {
-                    new()
-                    {
-                        Src = config.Filter,
-                        Dest = subjectTransform,
-                    },
-                },
+                SubjectTransforms = subjectTransforms,
             },
         };
 
@@ -563,6 +568,46 @@ public static class NatsPcgElasticExtensions
         }
 
         await js.CreateStreamAsync(streamConfig, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static SubjectTransform BuildSubjectTransform(NatsPcgPartitioningFilter pf, uint maxMembers)
+    {
+        bool isFullSubject = NatsPcgMemberMappingValidator.IsPartitionByFullSubject(pf.PartitioningWildcards);
+
+        // Build subject transform: add partition prefix based on wildcards
+        // Replace * wildcards with {{wildcard(N)}} in the filter
+        var filterTokens = pf.Filter.Split('.');
+        int wildcardIndex = 1;
+        for (int i = 0; i < filterTokens.Length; i++)
+        {
+            if (filterTokens[i] == "*")
+            {
+                filterTokens[i] = $"{{{{wildcard({wildcardIndex})}}}}";
+                wildcardIndex++;
+            }
+        }
+
+        string destFromFilter = string.Join(".", filterTokens);
+
+        string partitionFunction;
+        if (isFullSubject)
+        {
+            // {{Partition(N)}} without wildcard positions hashes the entire subject
+            partitionFunction = $"{{{{Partition({maxMembers})}}}}";
+        }
+        else
+        {
+            string wildcardStr = string.Join(",", pf.PartitioningWildcards);
+            partitionFunction = $"{{{{Partition({maxMembers},{wildcardStr})}}}}";
+        }
+
+        string subjectTransform = $"{partitionFunction}.{destFromFilter}";
+
+        return new SubjectTransform
+        {
+            Src = pf.Filter,
+            Dest = subjectTransform,
+        };
     }
 
     private static async Task<string[]> UpdateMembersAsync(

--- a/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticExtensions.cs
+++ b/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticExtensions.cs
@@ -308,6 +308,44 @@ public static class NatsPcgElasticExtensions
     }
 
     /// <summary>
+    /// Adds partitioning filters to an elastic consumer group.
+    /// </summary>
+    /// <param name="js">JetStream context.</param>
+    /// <param name="streamName">Name of the source stream.</param>
+    /// <param name="consumerGroupName">Name of the consumer group.</param>
+    /// <param name="partitioningFiltersToAdd">Partitioning filters to add.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Updated partitioning filters.</returns>
+    public static async Task<NatsPcgPartitioningFilter[]> AddPcgElasticFiltersAsync(
+        this INatsJSContext js,
+        string streamName,
+        string consumerGroupName,
+        NatsPcgPartitioningFilter[] partitioningFiltersToAdd,
+        CancellationToken cancellationToken = default)
+    {
+        return await UpdateFiltersAsync(js, streamName, consumerGroupName, partitioningFiltersToAdd, add: true, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Removes partitioning filters from an elastic consumer group.
+    /// </summary>
+    /// <param name="js">JetStream context.</param>
+    /// <param name="streamName">Name of the source stream.</param>
+    /// <param name="consumerGroupName">Name of the consumer group.</param>
+    /// <param name="partitioningFiltersToDrop">Partitioning filters to remove.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Updated partitioning filters.</returns>
+    public static async Task<NatsPcgPartitioningFilter[]> DeletePcgElasticFiltersAsync(
+        this INatsJSContext js,
+        string streamName,
+        string consumerGroupName,
+        NatsPcgPartitioningFilter[] partitioningFiltersToDrop,
+        CancellationToken cancellationToken = default)
+    {
+        return await UpdateFiltersAsync(js, streamName, consumerGroupName, partitioningFiltersToDrop, add: false, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Sets custom member-to-partition mappings.
     /// </summary>
     /// <param name="js">JetStream context.</param>
@@ -525,6 +563,23 @@ public static class NatsPcgElasticExtensions
         NatsPcgElasticConfig config,
         CancellationToken cancellationToken)
     {
+        var streamConfig = BuildWorkQueueStreamConfig(streamName, consumerGroupName, config);
+        await js.CreateStreamAsync(streamConfig, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task UpdateWorkQueueStreamAsync(
+        INatsJSContext js,
+        string streamName,
+        string consumerGroupName,
+        NatsPcgElasticConfig config,
+        CancellationToken cancellationToken)
+    {
+        var streamConfig = BuildWorkQueueStreamConfig(streamName, consumerGroupName, config);
+        await js.CreateOrUpdateStreamAsync(streamConfig, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static StreamConfig BuildWorkQueueStreamConfig(string streamName, string consumerGroupName, NatsPcgElasticConfig config)
+    {
         string workQueueStreamName = GetWorkQueueStreamName(streamName, consumerGroupName);
 
         var subjectTransforms = new List<SubjectTransform>();
@@ -567,7 +622,7 @@ public static class NatsPcgElasticExtensions
             streamConfig.MaxBytes = config.MaxBufferedBytes.Value;
         }
 
-        await js.CreateStreamAsync(streamConfig, cancellationToken).ConfigureAwait(false);
+        return streamConfig;
     }
 
     private static SubjectTransform BuildSubjectTransform(NatsPcgPartitioningFilter pf, uint maxMembers)
@@ -665,6 +720,91 @@ public static class NatsPcgElasticExtensions
             {
                 await store.UpdateAsync(key, updatedConfig, entry.Revision, serializer: NatsPcgJsonSerializer<NatsPcgElasticConfig>.Default, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return updatedMembers ?? Array.Empty<string>();
+            }
+            catch (NatsKVWrongLastRevisionException)
+            {
+                // Config changed - retry
+                if (retry < maxRetries - 1)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(50 * (retry + 1)), cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        throw new NatsPcgException("Failed to update config after maximum retries");
+    }
+
+    private static async Task<NatsPcgPartitioningFilter[]> UpdateFiltersAsync(
+        INatsJSContext js,
+        string streamName,
+        string consumerGroupName,
+        NatsPcgPartitioningFilter[] partitioningFilters,
+        bool add,
+        CancellationToken cancellationToken)
+    {
+        if (partitioningFilters == null)
+        {
+            throw new ArgumentNullException(nameof(partitioningFilters));
+        }
+
+        var kv = js.Connection.CreateKeyValueStoreContext();
+        var store = await kv.GetStoreAsync(NatsPcgConstants.ElasticKvBucket, cancellationToken).ConfigureAwait(false);
+        string key = GetKvKey(streamName, consumerGroupName);
+
+        // Retry loop for optimistic concurrency
+        const int maxRetries = 5;
+        for (int retry = 0; retry < maxRetries; retry++)
+        {
+            var entry = await store.GetEntryAsync(key, serializer: NatsPcgJsonSerializer<NatsPcgElasticConfig>.Default, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (entry.Value == null)
+            {
+                throw new NatsPcgException($"Consumer group '{consumerGroupName}' not found");
+            }
+
+            var config = entry.Value;
+            var updatedFilters = new SortedSet<NatsPcgPartitioningFilter>(config.PartitioningFilters, PartitioningFilterComparer.Instance);
+            var originalCount = updatedFilters.Count;
+
+            if (add)
+            {
+                foreach (var filter in partitioningFilters)
+                {
+                    updatedFilters.Add(filter);
+                }
+            }
+            else
+            {
+                foreach (var filter in partitioningFilters)
+                {
+                    updatedFilters.Remove(filter);
+                }
+            }
+
+            if (updatedFilters.Count == originalCount)
+            {
+                return config.PartitioningFilters;
+            }
+
+            if (updatedFilters.Count == 0)
+            {
+                throw new NatsPcgConfigurationException("At least one partitioning filter must be specified");
+            }
+
+            var filtersArray = updatedFilters.ToArray();
+            NatsPcgMemberMappingValidator.ValidatePartitioningFilters(filtersArray);
+
+            var updatedConfig = config with
+            {
+                PartitioningFilters = filtersArray,
+            };
+
+            // Keep work-queue stream source transforms in sync with config partitioning filters.
+            await UpdateWorkQueueStreamAsync(js, streamName, consumerGroupName, updatedConfig, cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                await store.UpdateAsync(key, updatedConfig, entry.Revision, serializer: NatsPcgJsonSerializer<NatsPcgElasticConfig>.Default, cancellationToken: cancellationToken).ConfigureAwait(false);
+                return filtersArray;
             }
             catch (NatsKVWrongLastRevisionException)
             {

--- a/src/Synadia.Orbit.PCGroups/NatsPcgMemberMappingValidator.cs
+++ b/src/Synadia.Orbit.PCGroups/NatsPcgMemberMappingValidator.cs
@@ -77,10 +77,10 @@ public static class NatsPcgMemberMappingValidator
     }
 
     /// <summary>
-    /// Validates filter and partitioning wildcards for elastic consumer groups.
+    /// Validates a partitioning filter for elastic consumer groups.
     /// </summary>
     /// <param name="filter">The subject filter.</param>
-    /// <param name="partitioningWildcards">The partitioning wildcard positions (1-indexed).</param>
+    /// <param name="partitioningWildcards">The partitioning wildcard positions (1-indexed). Empty array means partition by full subject.</param>
     /// <exception cref="NatsPcgConfigurationException">Thrown when validation fails.</exception>
     public static void ValidateFilterAndWildcards(string filter, int[] partitioningWildcards)
     {
@@ -89,25 +89,23 @@ public static class NatsPcgMemberMappingValidator
             throw new NatsPcgConfigurationException("Filter is required for elastic consumer groups");
         }
 
-        // Count wildcards in filter
-        var filterTokens = filter.Split('.');
-        int numWildcards = 0;
-        foreach (var token in filterTokens)
+        if (partitioningWildcards == null)
         {
-            if (token == "*")
-            {
-                numWildcards++;
-            }
+            throw new NatsPcgConfigurationException("PartitioningWildcards must not be null");
         }
+
+        // Empty array means partition by full subject - no wildcard requirements
+        if (IsPartitionByFullSubject(partitioningWildcards))
+        {
+            return;
+        }
+
+        // Count wildcards in filter
+        int numWildcards = CountWildcards(filter);
 
         if (numWildcards < 1)
         {
             throw new NatsPcgConfigurationException("Filter must contain at least one '*' wildcard");
-        }
-
-        if (partitioningWildcards == null || partitioningWildcards.Length == 0)
-        {
-            throw new NatsPcgConfigurationException("PartitioningWildcards must contain at least one element");
         }
 
         if (partitioningWildcards.Length > numWildcards)
@@ -132,5 +130,58 @@ public static class NatsPcgMemberMappingValidator
                     $"Duplicate partitioning wildcard position {pos}");
             }
         }
+    }
+
+    /// <summary>
+    /// Validates a partitioning filter record for elastic consumer groups.
+    /// </summary>
+    /// <param name="partitioningFilter">The partitioning filter to validate.</param>
+    /// <exception cref="NatsPcgConfigurationException">Thrown when validation fails.</exception>
+    public static void ValidatePartitioningFilter(NatsPcgPartitioningFilter partitioningFilter)
+    {
+        ValidateFilterAndWildcards(partitioningFilter.Filter, partitioningFilter.PartitioningWildcards);
+    }
+
+    /// <summary>
+    /// Validates multiple partitioning filters for elastic consumer groups.
+    /// </summary>
+    /// <param name="partitioningFilters">The partitioning filters to validate.</param>
+    /// <exception cref="NatsPcgConfigurationException">Thrown when validation fails.</exception>
+    public static void ValidatePartitioningFilters(NatsPcgPartitioningFilter[] partitioningFilters)
+    {
+        if (partitioningFilters == null)
+        {
+            return;
+        }
+
+        foreach (var pf in partitioningFilters)
+        {
+            ValidatePartitioningFilter(pf);
+        }
+    }
+
+    /// <summary>
+    /// Determines if the partitioning wildcards represent partition-by-full-subject mode.
+    /// </summary>
+    /// <param name="partitioningWildcards">The partitioning wildcard positions.</param>
+    /// <returns>True if the array is empty (partition by full subject).</returns>
+    public static bool IsPartitionByFullSubject(int[] partitioningWildcards)
+    {
+        return partitioningWildcards != null && partitioningWildcards.Length == 0;
+    }
+
+    private static int CountWildcards(string filter)
+    {
+        var filterTokens = filter.Split('.');
+        int numWildcards = 0;
+        foreach (var token in filterTokens)
+        {
+            if (token == "*")
+            {
+                numWildcards++;
+            }
+        }
+
+        return numWildcards;
     }
 }

--- a/src/Synadia.Orbit.PCGroups/NatsPcgPartitionDistributor.cs
+++ b/src/Synadia.Orbit.PCGroups/NatsPcgPartitionDistributor.cs
@@ -15,12 +15,14 @@ public static class NatsPcgPartitionDistributor
     /// <param name="maxMembers">Maximum number of members (equals number of partitions).</param>
     /// <param name="memberMappings">Optional explicit member-to-partition mappings.</param>
     /// <param name="memberName">The member name to generate filters for.</param>
-    /// <returns>Array of filters like ["0.>", "3.>", "6.>"].</returns>
+    /// <param name="filter">The subject filter to embed in partition filters.</param>
+    /// <returns>Array of filters like ["0.orders.*", "3.orders.*"].</returns>
     public static string[] GeneratePartitionFilters(
         string[]? members,
         uint maxMembers,
         NatsPcgMemberMapping[]? memberMappings,
-        string memberName)
+        string memberName,
+        string filter)
     {
         int[] partitions;
 
@@ -54,7 +56,7 @@ public static class NatsPcgPartitionDistributor
         string[] filters = new string[partitions.Length];
         for (int i = 0; i < partitions.Length; i++)
         {
-            filters[i] = $"{partitions[i]}.>";
+            filters[i] = $"{partitions[i]}.{filter}";
         }
 
         return filters;

--- a/src/Synadia.Orbit.PCGroups/NatsPcgPartitioningFilter.cs
+++ b/src/Synadia.Orbit.PCGroups/NatsPcgPartitioningFilter.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json.Serialization;
+
+namespace Synadia.Orbit.PCGroups;
+
+/// <summary>
+/// A filter with its associated partitioning wildcard positions for elastic consumer groups.
+/// </summary>
+public sealed record NatsPcgPartitioningFilter
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NatsPcgPartitioningFilter"/> class.
+    /// </summary>
+    /// <param name="filter">The subject filter (must contain at least one '*' wildcard).</param>
+    /// <param name="partitioningWildcards">The wildcard positions used for partitioning (1-indexed). Empty array means partition by full subject.</param>
+    public NatsPcgPartitioningFilter(string filter, int[] partitioningWildcards)
+    {
+        Filter = filter;
+        PartitioningWildcards = partitioningWildcards;
+    }
+
+    /// <summary>
+    /// Gets the subject filter.
+    /// </summary>
+    [JsonPropertyName("filter")]
+    public string Filter { get; init; }
+
+    /// <summary>
+    /// Gets the wildcard positions used for partitioning (1-indexed).
+    /// An empty array means partition by the entire subject string (server hashes the full subject).
+    /// </summary>
+    [JsonPropertyName("partitioning_wildcards")]
+    public int[] PartitioningWildcards { get; init; }
+}

--- a/src/Synadia.Orbit.PCGroups/NatsPcgPartitioningFilter.cs
+++ b/src/Synadia.Orbit.PCGroups/NatsPcgPartitioningFilter.cs
@@ -33,4 +33,101 @@ public sealed record NatsPcgPartitioningFilter
     /// </summary>
     [JsonPropertyName("partitioning_wildcards")]
     public int[] PartitioningWildcards { get; init; }
+
+    /// <inheritdoc />
+    public bool Equals(NatsPcgPartitioningFilter? other)
+    {
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (!string.Equals(Filter, other.Filter, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var leftWildcards = PartitioningWildcards ?? Array.Empty<int>();
+        var rightWildcards = other.PartitioningWildcards ?? Array.Empty<int>();
+
+        if (leftWildcards.Length != rightWildcards.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < leftWildcards.Length; i++)
+        {
+            if (leftWildcards[i] != rightWildcards[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            int hash = StringComparer.Ordinal.GetHashCode(Filter ?? string.Empty);
+            var wildcards = PartitioningWildcards ?? Array.Empty<int>();
+            for (int i = 0; i < wildcards.Length; i++)
+            {
+                hash = (hash * 397) ^ wildcards[i];
+            }
+
+            return hash;
+        }
+    }
+}
+
+internal sealed class PartitioningFilterComparer : IComparer<NatsPcgPartitioningFilter>
+{
+    internal static readonly PartitioningFilterComparer Instance = new();
+
+    public int Compare(NatsPcgPartitioningFilter? x, NatsPcgPartitioningFilter? y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return 0;
+        }
+
+        if (x is null)
+        {
+            return -1;
+        }
+
+        if (y is null)
+        {
+            return 1;
+        }
+
+        int filterCompare = string.Compare(x.Filter, y.Filter, StringComparison.Ordinal);
+        if (filterCompare != 0)
+        {
+            return filterCompare;
+        }
+
+        var xWildcards = x.PartitioningWildcards ?? Array.Empty<int>();
+        var yWildcards = y.PartitioningWildcards ?? Array.Empty<int>();
+
+        int minLength = Math.Min(xWildcards.Length, yWildcards.Length);
+        for (int i = 0; i < minLength; i++)
+        {
+            int wildcardCompare = xWildcards[i].CompareTo(yWildcards[i]);
+            if (wildcardCompare != 0)
+            {
+                return wildcardCompare;
+            }
+        }
+
+        return xWildcards.Length.CompareTo(yWildcards.Length);
+    }
 }

--- a/src/Synadia.Orbit.PCGroups/PACKAGE.md
+++ b/src/Synadia.Orbit.PCGroups/PACKAGE.md
@@ -216,6 +216,8 @@ Example: For `orders.*` with transform `{{partition(3,1)}}.orders.{{wildcard(1)}
 - `ListPcgElasticActiveMembersAsync` - List active members
 - `AddPcgElasticMembersAsync` - Add members to the group
 - `DeletePcgElasticMembersAsync` - Remove members from the group
+- `AddPcgElasticFiltersAsync` - Add partitioning filters to the group
+- `DeletePcgElasticFiltersAsync` - Remove partitioning filters from the group
 - `SetPcgElasticMemberMappingsAsync` - Set explicit partition mappings
 - `DeletePcgElasticMemberMappingsAsync` - Remove mappings (revert to auto-distribution)
 - `IsInPcgElasticMembershipAndActiveAsync` - Check if a member is in the group and active

--- a/src/Synadia.Orbit.PCGroups/PACKAGE.md
+++ b/src/Synadia.Orbit.PCGroups/PACKAGE.md
@@ -49,7 +49,7 @@ await js.CreatePcgStaticAsync(
     streamName: "orders",
     consumerGroupName: "order-processors",
     maxNumMembers: 3,
-    filter: "orders.*");
+    filters: ["orders.*"]);
 
 // Publish messages - they get transformed to {partition}.orders.{id}
 await js.PublishAsync("orders.123", new Order("ORD-123", "CUST-1", 99.99m));
@@ -90,8 +90,7 @@ await js.CreatePcgElasticAsync(
     streamName: "events",
     consumerGroupName: "event-processors",
     maxNumMembers: 10,
-    filter: "events.*",           // e.g., events.user123, events.user456
-    partitioningWildcards: [1]);  // Partition by the first wildcard (user ID)
+    partitioningFilters: [new NatsPcgPartitioningFilter("events.*", [1])]);
 
 // Add members dynamically - partitions will be distributed across them
 string[] members = ["worker-1", "worker-2", "worker-3"];
@@ -175,13 +174,13 @@ await js.CreateStreamAsync(new StreamConfig("orders", ["orders.*"])
 });
 
 await js.CreatePcgStaticAsync("orders", "processors", maxNumMembers: 6,
-    filter: "orders.*", memberMappings: mappings);
+    filters: ["orders.*"], memberMappings: mappings);
 
 // For elastic groups - no transform needed on source stream
 await js.CreateStreamAsync(new StreamConfig("events", ["events.*"]));
 
 await js.CreatePcgElasticAsync("events", "processors", maxNumMembers: 6,
-    filter: "events.*", partitioningWildcards: [1]);
+    partitioningFilters: [new NatsPcgPartitioningFilter("events.*", [1])]);
 await js.SetPcgElasticMemberMappingsAsync("events", "processors", mappings);
 ```
 

--- a/src/Synadia.Orbit.PCGroups/Static/NatsPcgStaticConfig.cs
+++ b/src/Synadia.Orbit.PCGroups/Static/NatsPcgStaticConfig.cs
@@ -17,10 +17,10 @@ public sealed record NatsPcgStaticConfig
     public required uint MaxMembers { get; init; }
 
     /// <summary>
-    /// Gets the optional filter for the consumer group.
+    /// Gets the optional list of subject filters for the consumer group.
     /// </summary>
-    [JsonPropertyName("filter")]
-    public string? Filter { get; init; }
+    [JsonPropertyName("filters")]
+    public string[]? Filters { get; init; }
 
     /// <summary>
     /// Gets the optional list of allowed member names.

--- a/src/Synadia.Orbit.PCGroups/Static/NatsPcgStaticConsumeContext.cs
+++ b/src/Synadia.Orbit.PCGroups/Static/NatsPcgStaticConsumeContext.cs
@@ -203,14 +203,7 @@ internal sealed class NatsPcgStaticConsumeContext<T> : IAsyncEnumerable<NatsPcgM
 
     private async Task CreateOrGetConsumerAsync(CancellationToken cancellationToken)
     {
-        var filters = NatsPcgPartitionDistributor.GeneratePartitionFilters(
-            _config.Members,
-            _config.MaxMembers,
-            _config.MemberMappings,
-            _memberName);
-
-        // Apply config filter to partition filters
-        var finalFilters = ApplyFilter(filters, _config.Filter);
+        var filters = GenerateFiltersForMember(_config, _memberName);
 
         // Each member gets its own consumer (named after consumer group + member)
         var consumerName = $"{_consumerGroupName}-{_memberName}";
@@ -220,7 +213,7 @@ internal sealed class NatsPcgStaticConsumeContext<T> : IAsyncEnumerable<NatsPcgM
             AckPolicy = _userConfig?.AckPolicy ?? ConsumerConfigAckPolicy.Explicit,
             AckWait = _userConfig?.AckWait ?? NatsPcgConstants.AckWait,
             MaxDeliver = _userConfig?.MaxDeliver ?? -1,
-            FilterSubjects = finalFilters,
+            FilterSubjects = filters,
             PriorityGroups = new[] { NatsPcgConstants.PriorityGroupName },
             PriorityPolicy = ConsumerConfigPriorityPolicy.PinnedClient,
             PinnedTTL = NatsPcgConstants.ConsumerIdleTimeout,
@@ -236,6 +229,32 @@ internal sealed class NatsPcgStaticConsumeContext<T> : IAsyncEnumerable<NatsPcgM
             // Consumer might already exist with different filter - try to get it
             _consumer = await _js.GetConsumerAsync(_streamName, consumerName, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    private static string[] GenerateFiltersForMember(NatsPcgStaticConfig config, string memberName)
+    {
+        if (config.Filters is { Length: > 0 })
+        {
+            var allFilters = new List<string>();
+            foreach (var f in config.Filters)
+            {
+                allFilters.AddRange(NatsPcgPartitionDistributor.GeneratePartitionFilters(
+                    config.Members,
+                    config.MaxMembers,
+                    config.MemberMappings,
+                    memberName,
+                    f));
+            }
+
+            return allFilters.ToArray();
+        }
+
+        return NatsPcgPartitionDistributor.GeneratePartitionFilters(
+            config.Members,
+            config.MaxMembers,
+            config.MemberMappings,
+            memberName,
+            ">");
     }
 
     private async Task WatchConfigLoopAsync()
@@ -320,24 +339,6 @@ internal sealed class NatsPcgStaticConsumeContext<T> : IAsyncEnumerable<NatsPcgM
         {
             // Expected when stopping
         }
-    }
-
-    private static string[] ApplyFilter(string[] partitionFilters, string? filter)
-    {
-        if (string.IsNullOrEmpty(filter))
-        {
-            return partitionFilters;
-        }
-
-        var result = new string[partitionFilters.Length];
-        for (int i = 0; i < partitionFilters.Length; i++)
-        {
-            // Replace .> with .{filter}
-            var prefix = partitionFilters[i].Substring(0, partitionFilters[i].Length - 1); // Remove ">"
-            result[i] = $"{prefix}{filter}";
-        }
-
-        return result;
     }
 
     // ReSharper disable once StaticMemberInGenericType

--- a/src/Synadia.Orbit.PCGroups/Static/NatsPcgStaticExtensions.cs
+++ b/src/Synadia.Orbit.PCGroups/Static/NatsPcgStaticExtensions.cs
@@ -23,7 +23,7 @@ public static class NatsPcgStaticExtensions
     /// <param name="streamName">Name of the stream to consume from.</param>
     /// <param name="consumerGroupName">Name of the consumer group.</param>
     /// <param name="maxNumMembers">Maximum number of members (also the number of partitions).</param>
-    /// <param name="filter">Optional subject filter.</param>
+    /// <param name="filters">Optional list of subject filters.</param>
     /// <param name="members">Optional list of allowed member names.</param>
     /// <param name="memberMappings">Optional explicit member-to-partition mappings.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -33,7 +33,7 @@ public static class NatsPcgStaticExtensions
         string streamName,
         string consumerGroupName,
         uint maxNumMembers,
-        string? filter = null,
+        string[]? filters = null,
         string[]? members = null,
         NatsPcgMemberMapping[]? memberMappings = null,
         CancellationToken cancellationToken = default)
@@ -46,7 +46,7 @@ public static class NatsPcgStaticExtensions
         var config = new NatsPcgStaticConfig
         {
             MaxMembers = maxNumMembers,
-            Filter = filter,
+            Filters = filters,
             Members = members,
             MemberMappings = memberMappings,
         };

--- a/src/Synadia.Orbit.PCGroups/version.txt
+++ b/src/Synadia.Orbit.PCGroups/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.5
+1.0.0-preview.6

--- a/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
@@ -24,35 +24,36 @@ public class NatsPcgElasticExtensionsTests
         var js = nats.CreateJetStreamContext();
 
         // Create a stream
-        var streamName = $"test-stream-{Guid.NewGuid():N}";
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
         await js.CreateStreamAsync(new StreamConfig
         {
             Name = streamName,
-            Subjects = new[] { "orders.>" },
+            Subjects = new[] { $"cgc{id}.>" },
         });
 
         try
         {
             // Create an elastic consumer group
-            var groupName = $"test-group-{Guid.NewGuid():N}";
+            var groupName = $"test-group-{id}";
             var config = await js.CreatePcgElasticAsync(
                 streamName,
                 groupName,
                 maxNumMembers: 3,
-                filter: "orders.*",
-                partitioningWildcards: [1]);
+                partitioningFilters: [new NatsPcgPartitioningFilter($"cgc{id}.*", [1])]);
 
             Assert.Equal(3u, config.MaxMembers);
-            Assert.Equal("orders.*", config.Filter);
-            Assert.Equal([1], config.PartitioningWildcards);
+            Assert.Single(config.PartitioningFilters);
+            Assert.Equal($"cgc{id}.*", config.PartitioningFilters[0].Filter);
+            Assert.Equal([1], config.PartitioningFilters[0].PartitioningWildcards);
             Assert.Null(config.Members);
             Assert.Null(config.MemberMappings);
 
             // Get the config back
             var retrieved = await js.GetPcgElasticConfigAsync(streamName, groupName);
             Assert.Equal(config.MaxMembers, retrieved.MaxMembers);
-            Assert.Equal(config.Filter, retrieved.Filter);
-            Assert.Equal(config.PartitioningWildcards, retrieved.PartitioningWildcards);
+            Assert.Equal(config.PartitioningFilters[0].Filter, retrieved.PartitioningFilters[0].Filter);
+            Assert.Equal(config.PartitioningFilters[0].PartitioningWildcards, retrieved.PartitioningFilters[0].PartitioningWildcards);
 
             // Clean up
             await js.DeletePcgElasticAsync(streamName, groupName);
@@ -69,22 +70,22 @@ public class NatsPcgElasticExtensionsTests
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
         var js = nats.CreateJetStreamContext();
 
-        var streamName = $"test-stream-{Guid.NewGuid():N}";
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
         await js.CreateStreamAsync(new StreamConfig
         {
             Name = streamName,
-            Subjects = new[] { "orders.>" },
+            Subjects = new[] { $"arm{id}.>" },
         });
 
         try
         {
-            var groupName = $"test-group-{Guid.NewGuid():N}";
+            var groupName = $"test-group-{id}";
             await js.CreatePcgElasticAsync(
                 streamName,
                 groupName,
                 maxNumMembers: 3,
-                filter: "orders.*",
-                partitioningWildcards: [1]);
+                partitioningFilters: [new NatsPcgPartitioningFilter($"arm{id}.*", [1])]);
 
             // Add members
             var members = await js.AddPcgElasticMembersAsync(streamName, groupName, ["member1", "member2"]);
@@ -120,22 +121,22 @@ public class NatsPcgElasticExtensionsTests
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
         var js = nats.CreateJetStreamContext();
 
-        var streamName = $"test-stream-{Guid.NewGuid():N}";
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
         await js.CreateStreamAsync(new StreamConfig
         {
             Name = streamName,
-            Subjects = new[] { "orders.>" },
+            Subjects = new[] { $"smm{id}.>" },
         });
 
         try
         {
-            var groupName = $"test-group-{Guid.NewGuid():N}";
+            var groupName = $"test-group-{id}";
             await js.CreatePcgElasticAsync(
                 streamName,
                 groupName,
                 maxNumMembers: 4,
-                filter: "orders.*",
-                partitioningWildcards: [1]);
+                partitioningFilters: [new NatsPcgPartitioningFilter($"smm{id}.*", [1])]);
 
             // Set explicit mappings
             var mappings = new[]
@@ -172,20 +173,21 @@ public class NatsPcgElasticExtensionsTests
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
         var js = nats.CreateJetStreamContext();
 
-        var streamName = $"test-stream-{Guid.NewGuid():N}";
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
         await js.CreateStreamAsync(new StreamConfig
         {
             Name = streamName,
-            Subjects = new[] { "orders.>" },
+            Subjects = new[] { $"lcg{id}.>" },
         });
 
         try
         {
-            var groupName1 = $"group1-{Guid.NewGuid():N}";
-            var groupName2 = $"group2-{Guid.NewGuid():N}";
+            var groupName1 = $"group1-{id}";
+            var groupName2 = $"group2-{id}";
 
-            await js.CreatePcgElasticAsync(streamName, groupName1, 3, "orders.*", [1]);
-            await js.CreatePcgElasticAsync(streamName, groupName2, 3, "orders.*", [1]);
+            await js.CreatePcgElasticAsync(streamName, groupName1, 3, [new NatsPcgPartitioningFilter($"lcg{id}.*", [1])]);
+            await js.CreatePcgElasticAsync(streamName, groupName2, 3, [new NatsPcgPartitioningFilter($"lcg{id}.*", [1])]);
 
             var groups = new List<string>();
             await foreach (var group in js.ListPcgElasticAsync(streamName))
@@ -211,17 +213,18 @@ public class NatsPcgElasticExtensionsTests
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
         var js = nats.CreateJetStreamContext();
 
-        var streamName = $"test-stream-{Guid.NewGuid():N}";
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
         await js.CreateStreamAsync(new StreamConfig
         {
             Name = streamName,
-            Subjects = new[] { "orders.>" },
+            Subjects = new[] { $"gpf{id}.>" },
         });
 
         try
         {
-            var groupName = $"test-group-{Guid.NewGuid():N}";
-            await js.CreatePcgElasticAsync(streamName, groupName, 4, "orders.*", [1]);
+            var groupName = $"test-group-{id}";
+            await js.CreatePcgElasticAsync(streamName, groupName, 4, [new NatsPcgPartitioningFilter($"gpf{id}.*", [1])]);
 
             // Add members
             await js.AddPcgElasticMembersAsync(streamName, groupName, ["a", "b"]);
@@ -235,8 +238,8 @@ public class NatsPcgElasticExtensionsTests
             var filtersA = config.GetPcgElasticPartitionFilters("a");
             var filtersB = config.GetPcgElasticPartitionFilters("b");
 
-            Assert.Equal(new[] { "0.>", "1.>" }, filtersA);
-            Assert.Equal(new[] { "2.>", "3.>" }, filtersB);
+            Assert.Equal(new[] { $"0.gpf{id}.*", $"1.gpf{id}.*" }, filtersA);
+            Assert.Equal(new[] { $"2.gpf{id}.*", $"3.gpf{id}.*" }, filtersB);
 
             await js.DeletePcgElasticAsync(streamName, groupName);
         }
@@ -257,27 +260,54 @@ public class NatsPcgElasticExtensionsTests
                 "stream",
                 "group",
                 maxNumMembers: 3,
-                filter: string.Empty,
-                partitioningWildcards: [1]));
+                partitioningFilters: [new NatsPcgPartitioningFilter(string.Empty, [1])]));
 
         Assert.Contains("required", exception.Message);
     }
 
     [Fact]
-    public async Task Validation_PartitioningWildcardsRequired()
+    public async Task CreatePcgElastic_EmptyPartitioningFilters_DefaultsToAllSubjects()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await SkipBelow212Async(nats);
         var js = nats.CreateJetStreamContext();
 
-        var exception = await Assert.ThrowsAsync<NatsPcgConfigurationException>(() =>
-            js.CreatePcgElasticAsync(
-                "stream",
-                "group",
-                maxNumMembers: 3,
-                filter: "orders.*",
-                partitioningWildcards: Array.Empty<int>()));
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = [$"epf{id}.>"],
+        });
 
-        Assert.Contains("at least one element", exception.Message);
+        try
+        {
+            var consumerGroupName = $"cg-{id}";
+            var config = await js.CreatePcgElasticAsync(
+                streamName,
+                consumerGroupName,
+                maxNumMembers: 3,
+                partitioningFilters: Array.Empty<NatsPcgPartitioningFilter>());
+
+            Assert.Equal(3U, config.MaxMembers);
+            Assert.Empty(config.PartitioningFilters);
+
+            // Verify the work-queue stream was created with ">" as the default source transform
+            var wqStreamName = $"{streamName}-{consumerGroupName}";
+            var streamInfo = await js.GetStreamAsync(wqStreamName);
+            Assert.NotNull(streamInfo);
+            var sources = streamInfo.Info.Config.Sources;
+            Assert.NotNull(sources);
+            Assert.Single(sources);
+            Assert.Single(sources.First().SubjectTransforms!);
+            Assert.Equal(">", sources.First().SubjectTransforms!.First().Src);
+
+            await js.DeletePcgElasticAsync(streamName, consumerGroupName);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
     }
 
     [Fact]
@@ -286,17 +316,18 @@ public class NatsPcgElasticExtensionsTests
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
         var js = nats.CreateJetStreamContext();
 
-        var streamName = $"test-stream-{Guid.NewGuid():N}";
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
         await js.CreateStreamAsync(new StreamConfig
         {
             Name = streamName,
-            Subjects = new[] { "orders.>" },
+            Subjects = new[] { $"vcm{id}.>" },
         });
 
         try
         {
-            var groupName = $"test-group-{Guid.NewGuid():N}";
-            await js.CreatePcgElasticAsync(streamName, groupName, 3, "orders.*", [1]);
+            var groupName = $"test-group-{id}";
+            await js.CreatePcgElasticAsync(streamName, groupName, 3, [new NatsPcgPartitioningFilter($"vcm{id}.*", [1])]);
 
             // Set mappings
             await js.SetPcgElasticMemberMappingsAsync(streamName, groupName, [
@@ -323,26 +354,26 @@ public class NatsPcgElasticExtensionsTests
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
         var js = nats.CreateJetStreamContext();
 
-        var streamName = $"test-stream-{Guid.NewGuid():N}";
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
 
         // Create source stream (elastic creates work-queue stream with transforms)
         await js.CreateStreamAsync(new StreamConfig
         {
             Name = streamName,
-            Subjects = ["events.*"],
+            Subjects = [$"ram{id}.*"],
         });
 
         try
         {
-            var groupName = $"test-group-{Guid.NewGuid():N}";
+            var groupName = $"test-group-{id}";
 
             // Create elastic consumer group
             await js.CreatePcgElasticAsync(
                 streamName,
                 groupName,
                 maxNumMembers: 10,
-                filter: "events.*",
-                partitioningWildcards: [1]);
+                partitioningFilters: [new NatsPcgPartitioningFilter($"ram{id}.*", [1])]);
 
             // Add members
             await js.AddPcgElasticMembersAsync(streamName, groupName, ["w1", "w2", "w3"]);
@@ -351,7 +382,7 @@ public class NatsPcgElasticExtensionsTests
             const int messageCount = 10;
             for (int i = 0; i < messageCount; i++)
             {
-                await js.PublishAsync($"events.user{i}", $"payload-{i}");
+                await js.PublishAsync($"ram{id}.user{i}", $"payload-{i}");
             }
 
             // Consume with all members concurrently using a channel
@@ -404,40 +435,40 @@ public class NatsPcgElasticExtensionsTests
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
         var js = nats.CreateJetStreamContext();
 
-        var streamName = $"test-stream-{Guid.NewGuid():N}";
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
 
         // Create source stream
         await js.CreateStreamAsync(new StreamConfig
         {
             Name = streamName,
-            Subjects = ["test.*"],
+            Subjects = [$"spp{id}.*"],
         });
 
         try
         {
-            var groupName = $"test-group-{Guid.NewGuid():N}";
+            var groupName = $"test-group-{id}";
 
             // Create elastic consumer group
             await js.CreatePcgElasticAsync(
                 streamName,
                 groupName,
                 maxNumMembers: 10,
-                filter: "test.*",
-                partitioningWildcards: [1]);
+                partitioningFilters: [new NatsPcgPartitioningFilter($"spp{id}.*", [1])]);
 
             // Add single member (gets all partitions)
             await js.AddPcgElasticMembersAsync(streamName, groupName, ["worker"]);
 
             // Publish a message
-            await js.PublishAsync("test.mykey", "payload");
+            await js.PublishAsync($"spp{id}.mykey", "payload");
 
             // Consume and verify subject is stripped
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
             await foreach (var msg in js.ConsumePcgElasticAsync<string>(streamName, groupName, "worker", cancellationToken: cts.Token))
             {
-                // Subject should be "test.mykey", not "{partition}.test.mykey"
-                Assert.Equal("test.mykey", msg.Subject);
+                // Subject should be "spp{id}.mykey", not "{partition}.spp{id}.mykey"
+                Assert.Equal($"spp{id}.mykey", msg.Subject);
                 await msg.AckAsync();
                 break;
             }
@@ -456,33 +487,33 @@ public class NatsPcgElasticExtensionsTests
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
         var js = nats.CreateJetStreamContext();
 
-        var streamName = $"test-stream-{Guid.NewGuid():N}";
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
 
         await js.CreateStreamAsync(new StreamConfig
         {
             Name = streamName,
-            Subjects = ["events.*"],
+            Subjects = [$"emc{id}.*"],
         });
 
         try
         {
-            var groupName = $"test-group-{Guid.NewGuid():N}";
+            var groupName = $"test-group-{id}";
 
             await js.CreatePcgElasticAsync(
                 streamName,
                 groupName,
                 maxNumMembers: 4,
-                filter: "events.*",
-                partitioningWildcards: [1]);
+                partitioningFilters: [new NatsPcgPartitioningFilter($"emc{id}.*", [1])]);
 
             // Add two members
             await js.AddPcgElasticMembersAsync(streamName, groupName, ["memberA", "memberB"]);
 
             // Publish messages that will go to different partitions
-            await js.PublishAsync("events.key1", "payload1");
-            await js.PublishAsync("events.key2", "payload2");
-            await js.PublishAsync("events.key3", "payload3");
-            await js.PublishAsync("events.key4", "payload4");
+            await js.PublishAsync($"emc{id}.key1", "payload1");
+            await js.PublishAsync($"emc{id}.key2", "payload2");
+            await js.PublishAsync($"emc{id}.key3", "payload3");
+            await js.PublishAsync($"emc{id}.key4", "payload4");
 
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             var memberAMessages = new List<string>();
@@ -542,5 +573,379 @@ public class NatsPcgElasticExtensionsTests
         {
             await js.DeleteStreamAsync(streamName);
         }
+    }
+
+    [Fact]
+    public async Task CreatePcgElastic_MultipleFilters_Success()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var js = nats.CreateJetStreamContext();
+
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
+
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = [$"ord{id}.*", $"ref{id}.*"],
+        });
+
+        try
+        {
+            var groupName = $"test-group-{id}";
+
+            var config = await js.CreatePcgElasticAsync(
+                streamName,
+                groupName,
+                maxNumMembers: 3,
+                partitioningFilters:
+                [
+                    new NatsPcgPartitioningFilter($"ord{id}.*", [1]),
+                    new NatsPcgPartitioningFilter($"ref{id}.*", [1]),
+                ]);
+
+            Assert.Equal(3u, config.MaxMembers);
+            Assert.Equal(2, config.PartitioningFilters.Length);
+            Assert.Equal($"ord{id}.*", config.PartitioningFilters[0].Filter);
+            Assert.Equal($"ref{id}.*", config.PartitioningFilters[1].Filter);
+
+            // Verify config round-trip
+            var retrieved = await js.GetPcgElasticConfigAsync(streamName, groupName);
+            Assert.Equal(2, retrieved.PartitioningFilters.Length);
+            Assert.Equal($"ord{id}.*", retrieved.PartitioningFilters[0].Filter);
+            Assert.Equal($"ref{id}.*", retrieved.PartitioningFilters[1].Filter);
+
+            await js.DeletePcgElasticAsync(streamName, groupName);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    [Fact]
+    public async Task ConsumeElastic_MultipleFilters_ReceivesFromAllFilters()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var js = nats.CreateJetStreamContext();
+
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
+
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = [$"ord{id}.*", $"ref{id}.*"],
+        });
+
+        try
+        {
+            var groupName = $"test-group-{id}";
+
+            await js.CreatePcgElasticAsync(
+                streamName,
+                groupName,
+                maxNumMembers: 3,
+                partitioningFilters:
+                [
+                    new NatsPcgPartitioningFilter($"ord{id}.*", [1]),
+                    new NatsPcgPartitioningFilter($"ref{id}.*", [1]),
+                ]);
+
+            // Add a member
+            await js.AddPcgElasticMembersAsync(streamName, groupName, ["worker"]);
+
+            // Publish messages to both subject patterns
+            await js.PublishAsync($"ord{id}.item1", "order1");
+            await js.PublishAsync($"ref{id}.item2", "refund1");
+            await js.PublishAsync($"ord{id}.item3", "order2");
+            await js.PublishAsync($"ref{id}.item4", "refund2");
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var receivedSubjects = new List<string>();
+
+            await foreach (var msg in js.ConsumePcgElasticAsync<string>(streamName, groupName, "worker", cancellationToken: cts.Token))
+            {
+                receivedSubjects.Add(msg.Subject);
+                await msg.AckAsync(cancellationToken: cts.Token);
+                if (receivedSubjects.Count >= 4)
+                {
+                    break;
+                }
+            }
+
+            Assert.Equal(4, receivedSubjects.Count);
+            Assert.Contains(receivedSubjects, s => s.StartsWith($"ord{id}."));
+            Assert.Contains(receivedSubjects, s => s.StartsWith($"ref{id}."));
+
+            await js.DeletePcgElasticAsync(streamName, groupName, cancellationToken: cts.Token);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    [Fact]
+    public async Task CreatePcgElastic_EmptyWildcards_FullSubjectPartition_Success()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await SkipBelow212Async(nats);
+        var js = nats.CreateJetStreamContext();
+
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
+
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = [$"ewf{id}.*"],
+        });
+
+        try
+        {
+            var groupName = $"test-group-{id}";
+
+            var config = await js.CreatePcgElasticAsync(
+                streamName,
+                groupName,
+                maxNumMembers: 3,
+                partitioningFilters: [new NatsPcgPartitioningFilter($"ewf{id}.*", Array.Empty<int>())]);
+
+            Assert.Equal(3u, config.MaxMembers);
+            Assert.Single(config.PartitioningFilters);
+            Assert.Empty(config.PartitioningFilters[0].PartitioningWildcards);
+
+            // Verify config round-trip
+            var retrieved = await js.GetPcgElasticConfigAsync(streamName, groupName);
+            Assert.Empty(retrieved.PartitioningFilters[0].PartitioningWildcards);
+
+            await js.DeletePcgElasticAsync(streamName, groupName);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    [Fact]
+    public async Task ConsumeElastic_EmptyWildcards_ReceivesAllMessages()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await SkipBelow212Async(nats);
+        var js = nats.CreateJetStreamContext();
+
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
+
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = [$"ewr{id}.*"],
+        });
+
+        try
+        {
+            var groupName = $"test-group-{id}";
+
+            await js.CreatePcgElasticAsync(
+                streamName,
+                groupName,
+                maxNumMembers: 3,
+                partitioningFilters: [new NatsPcgPartitioningFilter($"ewr{id}.*", Array.Empty<int>())]);
+
+            // Single member gets all partitions
+            await js.AddPcgElasticMembersAsync(streamName, groupName, ["worker"]);
+
+            // Publish messages
+            await js.PublishAsync($"ewr{id}.key1", "payload1");
+            await js.PublishAsync($"ewr{id}.key2", "payload2");
+            await js.PublishAsync($"ewr{id}.key3", "payload3");
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var receivedSubjects = new List<string>();
+
+            await foreach (var msg in js.ConsumePcgElasticAsync<string>(streamName, groupName, "worker", cancellationToken: cts.Token))
+            {
+                receivedSubjects.Add(msg.Subject);
+                await msg.AckAsync();
+                if (receivedSubjects.Count >= 3)
+                {
+                    break;
+                }
+            }
+
+            Assert.Equal(3, receivedSubjects.Count);
+            Assert.Contains($"ewr{id}.key1", receivedSubjects);
+            Assert.Contains($"ewr{id}.key2", receivedSubjects);
+            Assert.Contains($"ewr{id}.key3", receivedSubjects);
+
+            await js.DeletePcgElasticAsync(streamName, groupName);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    [Fact]
+    public async Task ConsumeElastic_EmptyWildcards_PartitionsAcrossMembers()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await SkipBelow212Async(nats);
+        var js = nats.CreateJetStreamContext();
+
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
+
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = [$"ewp{id}.*"],
+        });
+
+        try
+        {
+            var groupName = $"test-group-{id}";
+
+            // 4 partitions, empty wildcards means partition by full subject hash
+            await js.CreatePcgElasticAsync(
+                streamName,
+                groupName,
+                maxNumMembers: 4,
+                partitioningFilters: [new NatsPcgPartitioningFilter($"ewp{id}.*", Array.Empty<int>())]);
+
+            await js.AddPcgElasticMembersAsync(streamName, groupName, ["memberA", "memberB"]);
+
+            // Publish enough messages to different subjects so partitions get spread
+            for (int i = 0; i < 20; i++)
+            {
+                await js.PublishAsync($"ewp{id}.item{i}", $"payload{i}");
+            }
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            var memberAMessages = new List<string>();
+            var memberBMessages = new List<string>();
+
+            var taskA = Task.Run(async () =>
+            {
+                try
+                {
+                    await foreach (var msg in js.ConsumePcgElasticAsync<string>(streamName, groupName, "memberA", cancellationToken: cts.Token))
+                    {
+                        memberAMessages.Add(msg.Subject);
+                        await msg.AckAsync();
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            });
+
+            var taskB = Task.Run(async () =>
+            {
+                try
+                {
+                    await foreach (var msg in js.ConsumePcgElasticAsync<string>(streamName, groupName, "memberB", cancellationToken: cts.Token))
+                    {
+                        memberBMessages.Add(msg.Subject);
+                        await msg.AckAsync();
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            });
+
+            // Wait for all 20 messages
+            while (memberAMessages.Count + memberBMessages.Count < 20 && !cts.Token.IsCancellationRequested)
+            {
+                await Task.Delay(100, cts.Token);
+            }
+
+            cts.Cancel();
+            await Task.WhenAll(taskA, taskB);
+
+            // Both members should have received messages (full-subject hash distributes across partitions)
+            Assert.True(memberAMessages.Count > 0, "memberA should receive messages");
+            Assert.True(memberBMessages.Count > 0, "memberB should receive messages");
+            Assert.Equal(20, memberAMessages.Count + memberBMessages.Count);
+
+            // No overlap - each message goes to exactly one member
+            var allMessages = memberAMessages.Concat(memberBMessages).ToList();
+            Assert.Equal(allMessages.Count, allMessages.Distinct().Count());
+
+            // Verify determinism: publish the same subjects again and check same member gets them
+            // (This proves server is hashing the full subject, not round-robining)
+            for (int i = 0; i < 20; i++)
+            {
+                await js.PublishAsync($"ewp{id}.item{i}", $"payload{i}-round2");
+            }
+
+            var memberARound2 = new List<string>();
+            var memberBRound2 = new List<string>();
+
+            using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+            var taskA2 = Task.Run(async () =>
+            {
+                try
+                {
+                    await foreach (var msg in js.ConsumePcgElasticAsync<string>(streamName, groupName, "memberA", cancellationToken: cts2.Token))
+                    {
+                        memberARound2.Add(msg.Subject);
+                        await msg.AckAsync();
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            });
+
+            var taskB2 = Task.Run(async () =>
+            {
+                try
+                {
+                    await foreach (var msg in js.ConsumePcgElasticAsync<string>(streamName, groupName, "memberB", cancellationToken: cts2.Token))
+                    {
+                        memberBRound2.Add(msg.Subject);
+                        await msg.AckAsync();
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            });
+
+            while (memberARound2.Count + memberBRound2.Count < 20 && !cts2.Token.IsCancellationRequested)
+            {
+                await Task.Delay(100, cts2.Token);
+            }
+
+            cts2.Cancel();
+            await Task.WhenAll(taskA2, taskB2);
+
+            Assert.Equal(20, memberARound2.Count + memberBRound2.Count);
+
+            // Same subjects should land on the same member both rounds
+            memberAMessages.Sort(StringComparer.Ordinal);
+            memberARound2.Sort(StringComparer.Ordinal);
+            memberBMessages.Sort(StringComparer.Ordinal);
+            memberBRound2.Sort(StringComparer.Ordinal);
+            Assert.Equal(memberAMessages, memberARound2);
+            Assert.Equal(memberBMessages, memberBRound2);
+
+            await js.DeletePcgElasticAsync(streamName, groupName);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    private static async Task SkipBelow212Async(NatsConnection nats)
+    {
+        await nats.ConnectRetryAsync();
+        Assert.SkipUnless(nats.HasMinServerVersion(2, 12), $"Server version {nats.ServerInfo?.Version} does not support empty-wildcards full-subject partitioning (requires 2.12+)");
     }
 }

--- a/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
@@ -116,6 +116,136 @@ public class NatsPcgElasticExtensionsTests
     }
 
     [Fact]
+    public async Task AddAndRemoveFilters_Success()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var js = nats.CreateJetStreamContext();
+
+        var streamName = $"test-stream-{Guid.NewGuid():N}";
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = new[] { "orders.*", "refunds.*" },
+        });
+
+        try
+        {
+            var groupName = $"test-group-{Guid.NewGuid():N}";
+            await js.CreatePcgElasticAsync(
+                streamName,
+                groupName,
+                maxNumMembers: 3,
+                partitioningFilters: [new NatsPcgPartitioningFilter("orders.*", [1])]);
+
+            var filters = await js.AddPcgElasticFiltersAsync(streamName, groupName, [
+                new NatsPcgPartitioningFilter("refunds.*", [1]),
+                new NatsPcgPartitioningFilter("orders.*", [1]),
+            ]);
+            Assert.Equal(2, filters.Length);
+            Assert.Equal("orders.*", filters[0].Filter);
+            Assert.Equal(new[] { 1 }, filters[0].PartitioningWildcards);
+            Assert.Equal("refunds.*", filters[1].Filter);
+            Assert.Equal(new[] { 1 }, filters[1].PartitioningWildcards);
+
+            var config = await js.GetPcgElasticConfigAsync(streamName, groupName);
+            Assert.Equal(2, config.PartitioningFilters.Length);
+            Assert.Equal("orders.*", config.PartitioningFilters[0].Filter);
+            Assert.Equal(new[] { 1 }, config.PartitioningFilters[0].PartitioningWildcards);
+            Assert.Equal("refunds.*", config.PartitioningFilters[1].Filter);
+            Assert.Equal(new[] { 1 }, config.PartitioningFilters[1].PartitioningWildcards);
+
+            var workQueueStreamName = $"{streamName}-{groupName}";
+            var workQueueStream = await js.GetStreamAsync(workQueueStreamName);
+            var source = Assert.Single(workQueueStream.Info.Config.Sources!);
+            var sourceFilters = source.SubjectTransforms!.Select(x => x.Src).ToArray();
+            Assert.Equal(new[] { "orders.*", "refunds.*" }, sourceFilters);
+
+            filters = await js.DeletePcgElasticFiltersAsync(streamName, groupName, [new NatsPcgPartitioningFilter("orders.*", [1])]);
+            Assert.Single(filters);
+            Assert.Equal("refunds.*", filters[0].Filter);
+            Assert.Equal(new[] { 1 }, filters[0].PartitioningWildcards);
+
+            config = await js.GetPcgElasticConfigAsync(streamName, groupName);
+            Assert.Single(config.PartitioningFilters);
+            Assert.Equal("refunds.*", config.PartitioningFilters[0].Filter);
+            Assert.Equal(new[] { 1 }, config.PartitioningFilters[0].PartitioningWildcards);
+
+            workQueueStream = await js.GetStreamAsync(workQueueStreamName);
+            source = Assert.Single(workQueueStream.Info.Config.Sources!);
+            sourceFilters = source.SubjectTransforms!.Select(x => x.Src).ToArray();
+            Assert.Equal(new[] { "refunds.*" }, sourceFilters);
+
+            await js.DeletePcgElasticAsync(streamName, groupName);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    [Fact]
+    public async Task Validation_CannotRemoveAllFilters()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var js = nats.CreateJetStreamContext();
+
+        var streamName = $"test-stream-{Guid.NewGuid():N}";
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = new[] { "orders.>" },
+        });
+
+        try
+        {
+            var groupName = $"test-group-{Guid.NewGuid():N}";
+            await js.CreatePcgElasticAsync(streamName, groupName, 3, [new NatsPcgPartitioningFilter("orders.*", [1])]);
+
+            var exception = await Assert.ThrowsAsync<NatsPcgConfigurationException>(() =>
+                js.DeletePcgElasticFiltersAsync(streamName, groupName, [new NatsPcgPartitioningFilter("orders.*", [1])]));
+
+            Assert.Contains("At least one partitioning filter", exception.Message);
+
+            await js.DeletePcgElasticAsync(streamName, groupName);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    [Fact]
+    public async Task Validation_AddInvalidFilter_ThrowsException()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var js = nats.CreateJetStreamContext();
+
+        var streamName = $"test-stream-{Guid.NewGuid():N}";
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = new[] { "orders.>", "refunds.>" },
+        });
+
+        try
+        {
+            var groupName = $"test-group-{Guid.NewGuid():N}";
+            await js.CreatePcgElasticAsync(streamName, groupName, 3, [new NatsPcgPartitioningFilter("orders.*", [1])]);
+
+            var exception = await Assert.ThrowsAsync<NatsPcgConfigurationException>(() =>
+                js.AddPcgElasticFiltersAsync(streamName, groupName, [new NatsPcgPartitioningFilter("refunds.>", [1])]));
+
+            Assert.Contains("wildcard", exception.Message);
+
+            await js.DeletePcgElasticAsync(streamName, groupName);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    [Fact]
     public async Task SetMemberMappings_Success()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });

--- a/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticGoInteropTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticGoInteropTests.cs
@@ -1,0 +1,423 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using NATS.Client.Core;
+using NATS.Client.JetStream.Models;
+using NATS.Net;
+using Synadia.Orbit.PCGroups.Elastic;
+using Synadia.Orbit.Testing.GoHarness;
+using Synadia.Orbit.TestUtils;
+
+namespace Synadia.Orbit.PCGroups.Test.Elastic;
+
+[Collection("nats-server")]
+public class NatsPcgElasticGoInteropTests
+{
+    // lang=go
+    private const string GoConsumerCode =
+        """
+        package main
+
+        import (
+            "bufio"
+            "context"
+            "fmt"
+            "os"
+            "strconv"
+            "strings"
+            "sync/atomic"
+            "time"
+
+            "github.com/nats-io/nats.go"
+            "github.com/nats-io/nats.go/jetstream"
+            "github.com/synadia-io/orbit.go/pcgroups"
+        )
+
+        func main() {
+            scanner := bufio.NewScanner(os.Stdin)
+            if !scanner.Scan() {
+                fmt.Fprintln(os.Stderr, "no input")
+                os.Exit(1)
+            }
+
+            parts := strings.Split(scanner.Text(), "|")
+            natsUrl := parts[0]
+            streamName := parts[1]
+            groupName := parts[2]
+            memberName := parts[3]
+            expectedCount, _ := strconv.Atoi(parts[4])
+
+            nc, err := nats.Connect(natsUrl)
+            if err != nil {
+                fmt.Fprintf(os.Stderr, "connect: %v\n", err)
+                os.Exit(1)
+            }
+            defer nc.Close()
+
+            js, err := jetstream.New(nc)
+            if err != nil {
+                fmt.Fprintf(os.Stderr, "jetstream: %v\n", err)
+                os.Exit(1)
+            }
+
+            ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+            defer cancel()
+
+            config, err := pcgroups.GetElasticConsumerGroupConfig(ctx, js, streamName, groupName)
+            if err != nil {
+                fmt.Fprintf(os.Stderr, "get config: %v\n", err)
+                os.Exit(1)
+            }
+
+            filterDesc := ""
+            if len(config.PartitioningFilters) > 0 {
+                filterDesc = fmt.Sprintf(",filter=%s,wildcards=%v",
+                    config.PartitioningFilters[0].Filter,
+                    config.PartitioningFilters[0].PartitioningWildcards)
+            }
+            fmt.Printf("CONFIG:max_members=%d,filters=%d%s\n",
+                config.MaxMembers, len(config.PartitioningFilters), filterDesc)
+
+            var count atomic.Int32
+            var subjects []string
+
+            consumeCtx, err := pcgroups.ElasticConsume(ctx, js, streamName, groupName, memberName,
+                func(msg jetstream.Msg) {
+                    subjects = append(subjects, msg.Subject())
+                    msg.Ack()
+                    count.Add(1)
+                },
+                jetstream.ConsumerConfig{
+                    AckPolicy: jetstream.AckExplicitPolicy,
+                    AckWait:   5 * time.Second,
+                })
+            if err != nil {
+                fmt.Fprintf(os.Stderr, "consume: %v\n", err)
+                os.Exit(1)
+            }
+            defer consumeCtx.Stop()
+
+            deadline := time.After(15 * time.Second)
+            for {
+                if int(count.Load()) >= expectedCount {
+                    break
+                }
+                select {
+                case <-deadline:
+                    fmt.Fprintf(os.Stderr, "timeout waiting for messages, got %d/%d\n", count.Load(), expectedCount)
+                    os.Exit(1)
+                case <-time.After(100 * time.Millisecond):
+                }
+            }
+
+            fmt.Printf("RECEIVED:count=%d,subjects=%s\n", count.Load(), strings.Join(subjects, ","))
+        }
+        """;
+
+    // lang=go
+    private const string GoCreatorCode =
+        """
+        package main
+
+        import (
+            "bufio"
+            "context"
+            "fmt"
+            "os"
+            "strconv"
+            "strings"
+            "time"
+
+            "github.com/nats-io/nats.go"
+            "github.com/nats-io/nats.go/jetstream"
+            "github.com/synadia-io/orbit.go/pcgroups"
+        )
+
+        func main() {
+            scanner := bufio.NewScanner(os.Stdin)
+            if !scanner.Scan() {
+                fmt.Fprintln(os.Stderr, "no input")
+                os.Exit(1)
+            }
+
+            parts := strings.Split(scanner.Text(), "|")
+            natsUrl := parts[0]
+            streamName := parts[1]
+            groupName := parts[2]
+            subjectPrefix := parts[3]
+            messageCount, _ := strconv.Atoi(parts[4])
+
+            nc, err := nats.Connect(natsUrl)
+            if err != nil {
+                fmt.Fprintf(os.Stderr, "connect: %v\n", err)
+                os.Exit(1)
+            }
+            defer nc.Close()
+
+            js, err := jetstream.New(nc)
+            if err != nil {
+                fmt.Fprintf(os.Stderr, "jetstream: %v\n", err)
+                os.Exit(1)
+            }
+
+            ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+            defer cancel()
+
+            _, err = pcgroups.CreateElastic(ctx, js, streamName, groupName, 4,
+                []pcgroups.PartitioningFilter{
+                    {Filter: subjectPrefix + ".*", PartitioningWildcards: []int{1}},
+                }, 0, 0)
+            if err != nil {
+                fmt.Fprintf(os.Stderr, "create elastic: %v\n", err)
+                os.Exit(1)
+            }
+
+            _, err = pcgroups.AddMembers(ctx, js, streamName, groupName, []string{"dotnet-worker"})
+            if err != nil {
+                fmt.Fprintf(os.Stderr, "add members: %v\n", err)
+                os.Exit(1)
+            }
+
+            fmt.Println("CREATED")
+
+            for i := 0; i < messageCount; i++ {
+                subject := fmt.Sprintf("%s.item%d", subjectPrefix, i)
+                _, err := js.Publish(ctx, subject, []byte(fmt.Sprintf("payload%d", i)))
+                if err != nil {
+                    fmt.Fprintf(os.Stderr, "publish: %v\n", err)
+                    os.Exit(1)
+                }
+            }
+
+            fmt.Println("PUBLISHED")
+
+            scanner.Scan()
+        }
+        """;
+
+    private static readonly string[] GoModules =
+    [
+        "github.com/synadia-io/orbit.go/pcgroups@v0.2.0",
+        "github.com/nats-io/nats.go@v1.39.1",
+    ];
+
+    private readonly NatsServerFixture _server;
+
+    public NatsPcgElasticGoInteropTests(NatsServerFixture server) => _server = server;
+
+    [Fact]
+    public async Task DotNet_creates_Go_consumes()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await SkipBelow211Async(nats);
+        var js = nats.CreateJetStreamContext();
+
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"interop-{id}";
+
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = [$"ord{id}.*"],
+        });
+
+        try
+        {
+            var groupName = $"cg-{id}";
+
+            await js.CreatePcgElasticAsync(
+                streamName,
+                groupName,
+                maxNumMembers: 4,
+                partitioningFilters: [new NatsPcgPartitioningFilter($"ord{id}.*", [1])]);
+
+            await js.AddPcgElasticMembersAsync(streamName, groupName, ["go-worker"]);
+
+            for (int i = 0; i < 5; i++)
+            {
+                await js.PublishAsync($"ord{id}.item{i}", $"payload{i}");
+            }
+
+            await using var go = await GoProcess.RunCodeAsync(
+                GoConsumerCode,
+                logger: msg => { },
+                goModules: GoModules);
+
+            await go.WriteLineAsync($"{_server.Url}|{streamName}|{groupName}|go-worker|5");
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            var configLine = await go.ReadLineAsync(cts.Token);
+            Assert.NotNull(configLine);
+            Assert.StartsWith("CONFIG:", configLine);
+            Assert.Contains("max_members=4", configLine);
+            Assert.Contains("filters=1", configLine);
+            Assert.Contains($"filter=ord{id}.*", configLine);
+
+            var resultLine = await go.ReadLineAsync(cts.Token);
+            Assert.NotNull(resultLine);
+            Assert.StartsWith("RECEIVED:", resultLine);
+            Assert.Contains("count=5", resultLine);
+
+            go.CloseInput();
+            await go.WaitForExitAsync(cts.Token);
+            Assert.Equal(0, go.ExitCode);
+
+            await js.DeletePcgElasticAsync(streamName, groupName);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    [Fact]
+    public async Task Go_creates_DotNet_consumes()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await SkipBelow211Async(nats);
+        var js = nats.CreateJetStreamContext();
+
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"interop-{id}";
+
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = [$"evt{id}.*"],
+        });
+
+        try
+        {
+            var groupName = $"cg-{id}";
+
+            await using var go = await GoProcess.RunCodeAsync(
+                GoCreatorCode,
+                logger: msg => { },
+                goModules: GoModules);
+
+            await go.WriteLineAsync($"{_server.Url}|{streamName}|{groupName}|evt{id}|5");
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+            var readyLine = await go.ReadLineAsync(cts.Token);
+            Assert.NotNull(readyLine);
+            Assert.Equal("CREATED", readyLine);
+
+            var config = await js.GetPcgElasticConfigAsync(streamName, groupName, cts.Token);
+            Assert.Equal(4u, config.MaxMembers);
+            Assert.Single(config.PartitioningFilters);
+            Assert.Equal($"evt{id}.*", config.PartitioningFilters[0].Filter);
+            Assert.Equal([1], config.PartitioningFilters[0].PartitioningWildcards);
+            Assert.True(config.IsInMembership("dotnet-worker"));
+
+            var publishedLine = await go.ReadLineAsync(cts.Token);
+            Assert.NotNull(publishedLine);
+            Assert.Equal("PUBLISHED", publishedLine);
+
+            var received = new List<string>();
+            await foreach (var msg in js.ConsumePcgElasticAsync<string>(
+                               streamName, groupName, "dotnet-worker", cancellationToken: cts.Token))
+            {
+                received.Add(msg.Subject);
+                await msg.AckAsync(cancellationToken: cts.Token);
+                if (received.Count >= 5)
+                {
+                    break;
+                }
+            }
+
+            Assert.Equal(5, received.Count);
+            Assert.All(received, s => Assert.StartsWith($"evt{id}.", s));
+
+            go.CloseInput();
+            await go.WaitForExitAsync(cts.Token);
+            Assert.Equal(0, go.ExitCode);
+
+            await js.DeletePcgElasticAsync(streamName, groupName, cts.Token);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    [Fact]
+    public async Task DotNet_creates_empty_filters_Go_consumes()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await SkipBelow212Async(nats);
+        var js = nats.CreateJetStreamContext();
+
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"interop-{id}";
+
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = [$"efg{id}.*"],
+        });
+
+        try
+        {
+            var groupName = $"cg-{id}";
+
+            await js.CreatePcgElasticAsync(
+                streamName,
+                groupName,
+                maxNumMembers: 3,
+                partitioningFilters: Array.Empty<NatsPcgPartitioningFilter>());
+
+            await js.AddPcgElasticMembersAsync(streamName, groupName, ["go-worker"]);
+
+            for (int i = 0; i < 3; i++)
+            {
+                await js.PublishAsync($"efg{id}.item{i}", $"payload{i}");
+            }
+
+            await using var go = await GoProcess.RunCodeAsync(
+                GoConsumerCode,
+                logger: msg => { },
+                goModules: GoModules);
+
+            await go.WriteLineAsync($"{_server.Url}|{streamName}|{groupName}|go-worker|3");
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            var configLine = await go.ReadLineAsync(cts.Token);
+            Assert.NotNull(configLine);
+            Assert.StartsWith("CONFIG:", configLine);
+            Assert.Contains("max_members=3", configLine);
+            Assert.Contains("filters=0", configLine);
+
+            var resultLine = await go.ReadLineAsync(cts.Token);
+            Assert.NotNull(resultLine);
+            Assert.StartsWith("RECEIVED:", resultLine);
+            Assert.Contains("count=3", resultLine);
+
+            go.CloseInput();
+            await go.WaitForExitAsync(cts.Token);
+            Assert.Equal(0, go.ExitCode);
+
+            await js.DeletePcgElasticAsync(streamName, groupName);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    private static async Task SkipBelow211Async(NatsConnection nats)
+    {
+        await nats.ConnectRetryAsync();
+        Assert.SkipUnless(
+            nats.HasMinServerVersion(2, 11),
+            $"Server version {nats.ServerInfo?.Version} does not support priority groups (requires 2.11+)");
+    }
+
+    private static async Task SkipBelow212Async(NatsConnection nats)
+    {
+        await nats.ConnectRetryAsync();
+        Assert.SkipUnless(
+            nats.HasMinServerVersion(2, 12),
+            $"Server version {nats.ServerInfo?.Version} does not support empty-wildcards full-subject partitioning (requires 2.12+)");
+    }
+}

--- a/tests/Synadia.Orbit.PCGroups.Test/NatsPcgMemberMappingValidatorTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/NatsPcgMemberMappingValidatorTests.cs
@@ -234,16 +234,14 @@ public class NatsPcgMemberMappingValidatorTests
         var ex = Assert.Throws<NatsPcgConfigurationException>(() =>
             NatsPcgMemberMappingValidator.ValidateFilterAndWildcards("foo.*", null!));
 
-        Assert.Contains("at least one element", ex.Message);
+        Assert.Contains("must not be null", ex.Message);
     }
 
     [Fact]
-    public void ValidateFilterAndWildcards_EmptyPartitioningWildcards_ThrowsException()
+    public void ValidateFilterAndWildcards_EmptyPartitioningWildcards_FullSubject_NoException()
     {
-        var ex = Assert.Throws<NatsPcgConfigurationException>(() =>
-            NatsPcgMemberMappingValidator.ValidateFilterAndWildcards("foo.*", Array.Empty<int>()));
-
-        Assert.Contains("at least one element", ex.Message);
+        // Empty array means partition by full subject
+        NatsPcgMemberMappingValidator.ValidateFilterAndWildcards("foo.*", Array.Empty<int>());
     }
 
     [Fact]
@@ -290,5 +288,68 @@ public class NatsPcgMemberMappingValidatorTests
     {
         // Filter has 3 wildcards, using only 2 for partitioning
         NatsPcgMemberMappingValidator.ValidateFilterAndWildcards("foo.*.*.*.>", new[] { 1, 3 });
+    }
+
+    [Fact]
+    public void ValidatePartitioningFilters_ValidMultipleFilters_NoException()
+    {
+        NatsPcgMemberMappingValidator.ValidatePartitioningFilters(new[]
+        {
+            new NatsPcgPartitioningFilter("orders.*", new[] { 1 }),
+            new NatsPcgPartitioningFilter("refunds.*", new[] { 1 }),
+        });
+    }
+
+    [Fact]
+    public void ValidatePartitioningFilters_NullFilters_NoException()
+    {
+        NatsPcgMemberMappingValidator.ValidatePartitioningFilters(null!);
+    }
+
+    [Fact]
+    public void ValidatePartitioningFilters_EmptyFilters_NoException()
+    {
+        NatsPcgMemberMappingValidator.ValidatePartitioningFilters(Array.Empty<NatsPcgPartitioningFilter>());
+    }
+
+    [Fact]
+    public void ValidatePartitioningFilters_FilterWithoutWildcard_ThrowsException()
+    {
+        var ex = Assert.Throws<NatsPcgConfigurationException>(() =>
+            NatsPcgMemberMappingValidator.ValidatePartitioningFilters(new[]
+            {
+                new NatsPcgPartitioningFilter("orders.*", new[] { 1 }),
+                new NatsPcgPartitioningFilter("refunds.bar", new[] { 1 }),
+            }));
+
+        Assert.Contains("at least one '*' wildcard", ex.Message);
+    }
+
+    [Fact]
+    public void ValidatePartitioningFilters_EmptyWildcards_FullSubject_NoException()
+    {
+        NatsPcgMemberMappingValidator.ValidatePartitioningFilters(new[]
+        {
+            new NatsPcgPartitioningFilter("orders.*", Array.Empty<int>()),
+            new NatsPcgPartitioningFilter("refunds.*", Array.Empty<int>()),
+        });
+    }
+
+    [Fact]
+    public void IsPartitionByFullSubject_EmptyArray_ReturnsTrue()
+    {
+        Assert.True(NatsPcgMemberMappingValidator.IsPartitionByFullSubject(Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void IsPartitionByFullSubject_ExplicitPositions_ReturnsFalse()
+    {
+        Assert.False(NatsPcgMemberMappingValidator.IsPartitionByFullSubject(new[] { 1 }));
+    }
+
+    [Fact]
+    public void IsPartitionByFullSubject_NullArray_ReturnsFalse()
+    {
+        Assert.False(NatsPcgMemberMappingValidator.IsPartitionByFullSubject(null!));
     }
 }

--- a/tests/Synadia.Orbit.PCGroups.Test/NatsPcgPartitionDistributorTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/NatsPcgPartitionDistributorTests.cs
@@ -19,9 +19,9 @@ public class NatsPcgPartitionDistributorTests
         // m1 (index 0) gets partitions: 0, 1
         // m2 (index 1) gets partitions: 2, 3
         // m3 (index 2) gets partitions: 4, 5
-        var filtersM1 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 6, null, "m1");
-        var filtersM2 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 6, null, "m2");
-        var filtersM3 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 6, null, "m3");
+        var filtersM1 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 6, null, "m1", ">");
+        var filtersM2 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 6, null, "m2", ">");
+        var filtersM3 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 6, null, "m3", ">");
 
         Assert.Equal(new[] { "0.>", "1.>" }, filtersM1);
         Assert.Equal(new[] { "2.>", "3.>" }, filtersM2);
@@ -37,9 +37,9 @@ public class NatsPcgPartitionDistributorTests
         // m1 gets partitions: 0, 1, 6 (2 regular + 1 remainder)
         // m2 gets partitions: 2, 3
         // m3 gets partitions: 4, 5
-        var filtersM1 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 7, null, "m1");
-        var filtersM2 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 7, null, "m2");
-        var filtersM3 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 7, null, "m3");
+        var filtersM1 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 7, null, "m1", ">");
+        var filtersM2 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 7, null, "m2", ">");
+        var filtersM3 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 7, null, "m3", ">");
 
         Assert.Equal(new[] { "0.>", "1.>", "6.>" }, filtersM1);
         Assert.Equal(new[] { "2.>", "3.>" }, filtersM2);
@@ -55,9 +55,9 @@ public class NatsPcgPartitionDistributorTests
         // m1 gets partitions: 0, 1, 6 (2 regular + 1 remainder)
         // m2 gets partitions: 2, 3, 7 (2 regular + 1 remainder)
         // m3 gets partitions: 4, 5
-        var filtersM1 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 8, null, "m1");
-        var filtersM2 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 8, null, "m2");
-        var filtersM3 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 8, null, "m3");
+        var filtersM1 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 8, null, "m1", ">");
+        var filtersM2 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 8, null, "m2", ">");
+        var filtersM3 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 8, null, "m3", ">");
 
         Assert.Equal(new[] { "0.>", "1.>", "6.>" }, filtersM1);
         Assert.Equal(new[] { "2.>", "3.>", "7.>" }, filtersM2);
@@ -73,8 +73,8 @@ public class NatsPcgPartitionDistributorTests
             new NatsPcgMemberMapping("m2", new[] { 1 }),
         };
 
-        var filtersM1 = NatsPcgPartitionDistributor.GeneratePartitionFilters(null, 3, mappings, "m1");
-        var filtersM2 = NatsPcgPartitionDistributor.GeneratePartitionFilters(null, 3, mappings, "m2");
+        var filtersM1 = NatsPcgPartitionDistributor.GeneratePartitionFilters(null, 3, mappings, "m1", ">");
+        var filtersM2 = NatsPcgPartitionDistributor.GeneratePartitionFilters(null, 3, mappings, "m2", ">");
 
         Assert.Equal(new[] { "0.>", "2.>" }, filtersM1);
         Assert.Equal(new[] { "1.>" }, filtersM2);
@@ -86,7 +86,7 @@ public class NatsPcgPartitionDistributorTests
         var members = new[] { "m1", "m2" };
 
         var ex = Assert.Throws<NatsPcgMembershipException>(() =>
-            NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 2, null, "m3"));
+            NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 2, null, "m3", ">"));
 
         Assert.Contains("not found", ex.Message);
     }
@@ -95,7 +95,7 @@ public class NatsPcgPartitionDistributorTests
     public void GeneratePartitionFilters_EmptyMembership_ReturnsAllPartitions()
     {
         // When membership is null/empty, any member gets all partitions
-        var filters = NatsPcgPartitionDistributor.GeneratePartitionFilters(null, 3, null, "anyMember");
+        var filters = NatsPcgPartitionDistributor.GeneratePartitionFilters(null, 3, null, "anyMember", ">");
 
         Assert.Equal(new[] { "0.>", "1.>", "2.>" }, filters);
     }
@@ -107,8 +107,8 @@ public class NatsPcgPartitionDistributorTests
         var members1 = new[] { "c", "a", "b" };
         var members2 = new[] { "a", "b", "c" };
 
-        var filters1 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members1, 3, null, "a");
-        var filters2 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members2, 3, null, "a");
+        var filters1 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members1, 3, null, "a", ">");
+        var filters2 = NatsPcgPartitionDistributor.GeneratePartitionFilters(members2, 3, null, "a", ">");
 
         Assert.Equal(filters1, filters2);
     }

--- a/tests/Synadia.Orbit.PCGroups.Test/Static/NatsPcgStaticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Static/NatsPcgStaticExtensionsTests.cs
@@ -39,17 +39,17 @@ public class NatsPcgStaticExtensionsTests
                 streamName,
                 groupName,
                 maxNumMembers: 3,
-                filter: "test.>");
+                filters: ["test.>"]);
 
             Assert.Equal(3u, config.MaxMembers);
-            Assert.Equal("test.>", config.Filter);
+            Assert.Equal(new[] { "test.>" }, config.Filters);
             Assert.Null(config.Members);
             Assert.Null(config.MemberMappings);
 
             // Get the config back
             var retrieved = await js.GetPcgStaticConfigAsync(streamName, groupName);
             Assert.Equal(config.MaxMembers, retrieved.MaxMembers);
-            Assert.Equal(config.Filter, retrieved.Filter);
+            Assert.Equal(config.Filters, retrieved.Filters);
 
             // Clean up
             await js.DeletePcgStaticAsync(streamName, groupName);
@@ -187,9 +187,9 @@ public class NatsPcgStaticExtensionsTests
     {
         var members = new[] { "a", "b", "c" };
 
-        var filtersA = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 6, null, "a");
-        var filtersB = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 6, null, "b");
-        var filtersC = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 6, null, "c");
+        var filtersA = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 6, null, "a", ">");
+        var filtersB = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 6, null, "b", ">");
+        var filtersC = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 6, null, "c", ">");
 
         // With 6 partitions and 3 members (sorted: a, b, c):
         // Using contiguous block algorithm (matches Go implementation):
@@ -210,11 +210,23 @@ public class NatsPcgStaticExtensionsTests
             new NatsPcgMemberMapping("member2", [1, 3, 5]),
         };
 
-        var filters1 = NatsPcgPartitionDistributor.GeneratePartitionFilters(null, 6, mappings, "member1");
-        var filters2 = NatsPcgPartitionDistributor.GeneratePartitionFilters(null, 6, mappings, "member2");
+        var filters1 = NatsPcgPartitionDistributor.GeneratePartitionFilters(null, 6, mappings, "member1", ">");
+        var filters2 = NatsPcgPartitionDistributor.GeneratePartitionFilters(null, 6, mappings, "member2", ">");
 
         Assert.Equal(new[] { "0.>", "2.>", "4.>" }, filters1);
         Assert.Equal(new[] { "1.>", "3.>", "5.>" }, filters2);
+    }
+
+    [Fact]
+    public void PartitionDistributor_WithFilter()
+    {
+        var members = new[] { "a", "b" };
+
+        var filtersA = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 4, null, "a", "orders.*");
+        var filtersB = NatsPcgPartitionDistributor.GeneratePartitionFilters(members, 4, null, "b", "orders.*");
+
+        Assert.Equal(new[] { "0.orders.*", "1.orders.*" }, filtersA);
+        Assert.Equal(new[] { "2.orders.*", "3.orders.*" }, filtersB);
     }
 
     [Fact]
@@ -293,7 +305,7 @@ public class NatsPcgStaticExtensionsTests
                 streamName,
                 groupName,
                 maxNumMembers: 2,
-                filter: "orders.*",
+                filters: ["orders.*"],
                 members: ["m1", "m2"]);
 
             // Publish test messages
@@ -396,7 +408,7 @@ public class NatsPcgStaticExtensionsTests
                 streamName,
                 groupName,
                 maxNumMembers: 1,
-                filter: "test.*",
+                filters: ["test.*"],
                 members: ["worker"]);
 
             // Publish a message
@@ -412,6 +424,108 @@ public class NatsPcgStaticExtensionsTests
                 await msg.AckAsync();
                 break;
             }
+
+            await js.DeletePcgStaticAsync(streamName, groupName);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    [Fact]
+    public async Task CreateWithMultipleFilters_Success()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var js = nats.CreateJetStreamContext();
+
+        var streamName = $"test-stream-{Guid.NewGuid():N}";
+
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = ["orders.*", "refunds.*"],
+        });
+
+        try
+        {
+            var groupName = $"test-group-{Guid.NewGuid():N}";
+
+            var config = await js.CreatePcgStaticAsync(
+                streamName,
+                groupName,
+                maxNumMembers: 3,
+                filters: ["orders.*", "refunds.*"]);
+
+            Assert.Equal(3u, config.MaxMembers);
+            Assert.Equal(new[] { "orders.*", "refunds.*" }, config.Filters);
+
+            // Verify config round-trip
+            var retrieved = await js.GetPcgStaticConfigAsync(streamName, groupName);
+            Assert.Equal(new[] { "orders.*", "refunds.*" }, retrieved.Filters);
+
+            await js.DeletePcgStaticAsync(streamName, groupName);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    [Fact]
+    public async Task ConsumeStatic_MultipleFilters_ReceivesFromAllFilters()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var js = nats.CreateJetStreamContext();
+
+        var streamName = $"test-stream-{Guid.NewGuid():N}";
+
+        // Create stream with subject transforms for both subject patterns
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = ["orders.*", "refunds.*"],
+            SubjectTransform = new SubjectTransform
+            {
+                Src = "*.*",
+                Dest = "{{partition(2,2)}}.{{wildcard(1)}}.{{wildcard(2)}}",
+            },
+        });
+
+        try
+        {
+            var groupName = $"test-group-{Guid.NewGuid():N}";
+
+            // Create static consumer group with multiple filters
+            await js.CreatePcgStaticAsync(
+                streamName,
+                groupName,
+                maxNumMembers: 2,
+                filters: ["orders.*", "refunds.*"],
+                members: ["worker"]);
+
+            // Publish messages to both subject patterns
+            await js.PublishAsync("orders.item1", "order1");
+            await js.PublishAsync("refunds.item2", "refund1");
+            await js.PublishAsync("orders.item3", "order2");
+            await js.PublishAsync("refunds.item4", "refund2");
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var receivedSubjects = new List<string>();
+
+            await foreach (var msg in js.ConsumePcgStaticAsync<string>(streamName, groupName, "worker", cancellationToken: cts.Token))
+            {
+                receivedSubjects.Add(msg.Subject);
+                await msg.AckAsync();
+                if (receivedSubjects.Count >= 4)
+                {
+                    break;
+                }
+            }
+
+            Assert.Equal(4, receivedSubjects.Count);
+            Assert.Contains(receivedSubjects, s => s.StartsWith("orders."));
+            Assert.Contains(receivedSubjects, s => s.StartsWith("refunds."));
 
             await js.DeletePcgStaticAsync(streamName, groupName);
         }

--- a/tests/Synadia.Orbit.PCGroups.Test/Synadia.Orbit.PCGroups.Test.csproj
+++ b/tests/Synadia.Orbit.PCGroups.Test/Synadia.Orbit.PCGroups.Test.csproj
@@ -33,6 +33,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Synadia.Orbit.PCGroups\Synadia.Orbit.PCGroups.csproj" />
+    <ProjectReference Include="..\..\src\Synadia.Orbit.Testing.GoHarness\Synadia.Orbit.Testing.GoHarness.csproj" />
     <ProjectReference Include="..\Synadia.Orbit.TestUtils\Synadia.Orbit.TestUtils.csproj"/>
   </ItemGroup>
 

--- a/tools/DocsExamples/ExamplePCGroups.cs
+++ b/tools/DocsExamples/ExamplePCGroups.cs
@@ -50,7 +50,7 @@ public class ExamplePCGroups
                     streamName: "orders",
                     consumerGroupName: "order-processors",
                     maxNumMembers: 3,
-                    filter: "orders.*");
+                    filters: ["orders.*"]);
 
                 // Publish some test messages - they get transformed to {partition}.orders.{id}
                 for (int i = 0; i < 5; i++)
@@ -102,8 +102,7 @@ public class ExamplePCGroups
                     streamName: "events",
                     consumerGroupName: "event-processors",
                     maxNumMembers: 10,
-                    filter: "events.*",           // e.g., events.user123, events.user456
-                    partitioningWildcards: [1]);  // Partition by the first wildcard (user ID)
+                    partitioningFilters: [new NatsPcgPartitioningFilter("events.*", [1])]);
 
                 // Add members dynamically - partitions will be distributed across them
                 string[] members = ["worker-1", "worker-2", "worker-3"];
@@ -199,11 +198,11 @@ public class ExamplePCGroups
                 };
 
                 await js.CreatePcgStaticAsync("orders2", "processors", maxNumMembers: 6,
-                    filter: "orders2.*", memberMappings: mappings);
+                    filters: ["orders2.*"], memberMappings: mappings);
 
                 // For elastic groups
                 await js.CreatePcgElasticAsync("events2", "processors", maxNumMembers: 6,
-                    filter: "events2.*", partitioningWildcards: [1]);
+                    partitioningFilters: [new NatsPcgPartitioningFilter("events2.*", [1])]);
                 await js.SetPcgElasticMemberMappingsAsync("events2", "processors", mappings);
 
                 Console.WriteLine("Created consumer groups with custom mappings.");

--- a/tools/OrbitPcg/Program.cs
+++ b/tools/OrbitPcg/Program.cs
@@ -67,7 +67,7 @@ staticInfoCommand.SetAction(async (parseResult, ct) =>
     Console.WriteLine($"Static Consumer Group: {name}");
     Console.WriteLine($"  Stream:      {stream}");
     Console.WriteLine($"  MaxMembers:  {config.MaxMembers}");
-    Console.WriteLine($"  Filter:      {config.Filter ?? "(none)"}");
+    Console.WriteLine($"  Filters:     {(config.Filters != null ? string.Join(", ", config.Filters) : "(none)")}");
 
     if (config.Members != null)
     {
@@ -130,12 +130,12 @@ staticCreateCommand.SetAction(async (parseResult, ct) =>
     }
 
     var config = await js.CreatePcgStaticAsync(stream, name, maxMembers,
-        filter: filter, members: members, memberMappings: mappings, cancellationToken: ct);
+        filters: filter != null ? [filter] : null, members: members, memberMappings: mappings, cancellationToken: ct);
 
     Console.WriteLine($"Created static consumer group '{name}' on stream '{stream}'");
     Console.WriteLine($"  MaxMembers: {config.MaxMembers}");
-    if (config.Filter != null)
-        Console.WriteLine($"  Filter: {config.Filter}");
+    if (config.Filters != null)
+        Console.WriteLine($"  Filters: {string.Join(", ", config.Filters)}");
 });
 staticCommand.Add(staticCreateCommand);
 
@@ -329,8 +329,14 @@ elasticInfoCommand.SetAction(async (parseResult, ct) =>
     Console.WriteLine($"Elastic Consumer Group: {name}");
     Console.WriteLine($"  Stream:                {stream}");
     Console.WriteLine($"  MaxMembers:            {config.MaxMembers}");
-    Console.WriteLine($"  Filter:                {config.Filter}");
-    Console.WriteLine($"  PartitioningWildcards: [{string.Join(", ", config.PartitioningWildcards)}]");
+    if (config.PartitioningFilters != null)
+    {
+        Console.WriteLine("  PartitioningFilters:");
+        foreach (var pf in config.PartitioningFilters)
+        {
+            Console.WriteLine($"    {pf.Filter}: [{string.Join(", ", pf.PartitioningWildcards)}]");
+        }
+    }
 
     if (config.MaxBufferedMsgs.HasValue)
         Console.WriteLine($"  MaxBufferedMsgs:       {config.MaxBufferedMsgs}");
@@ -393,13 +399,20 @@ elasticCreateCommand.SetAction(async (parseResult, ct) =>
     await using var nats = new NatsConnection(new NatsOpts { Url = server });
     var js = nats.CreateJetStreamContext();
 
-    var config = await js.CreatePcgElasticAsync(stream, name, maxMembers, filter, wildcards,
+    var partitioningFilters = new[] { new NatsPcgPartitioningFilter(filter, wildcards) };
+    var config = await js.CreatePcgElasticAsync(stream, name, maxMembers, partitioningFilters,
         maxBufferedMessages: maxMsgs, maxBufferedBytes: maxBytes, cancellationToken: ct);
 
     Console.WriteLine($"Created elastic consumer group '{name}' on stream '{stream}'");
     Console.WriteLine($"  MaxMembers:            {config.MaxMembers}");
-    Console.WriteLine($"  Filter:                {config.Filter}");
-    Console.WriteLine($"  PartitioningWildcards: [{string.Join(", ", config.PartitioningWildcards)}]");
+    if (config.PartitioningFilters != null)
+    {
+        Console.WriteLine("  PartitioningFilters:");
+        foreach (var pf in config.PartitioningFilters)
+        {
+            Console.WriteLine($"    {pf.Filter}: [{string.Join(", ", pf.PartitioningWildcards)}]");
+        }
+    }
 });
 elasticCommand.Add(elasticCreateCommand);
 


### PR DESCRIPTION
This PR adds runtime partitioning-filter management for Elastic PCGroups and fixes NatsPcgPartitioningFilter value semantics.

  ### Changes

  - Added:
      - AddPcgElasticFiltersAsync(...)
      - DeletePcgElasticFiltersAsync(...)
  - NatsPcgPartitioningFilter now compares by value (Filter + PartitioningWildcards) via custom Equals/GetHashCode.
