### PR TITLE
Release PCGroups 1.0.0-preview.6

### DIFF
--- a/src/Synadia.Orbit.PCGroups/version.txt
+++ b/src/Synadia.Orbit.PCGroups/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.5
+1.0.0-preview.6


### PR DESCRIPTION
Bumps PCGroups to 1.0.0-preview.6. Changes since preview.5:

- Multiple filters per consumer group (static and elastic)
- Empty PartitioningFilters defaults to full-subject partitioning (NATS 2.12+)
- Cross-language interop with orbit.go pcgroups v0.2.0
- Go interop tests via GoHarness