### PR TITLE
Support updating PCGroup filters dynamically

### DIFF
--- a/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticExtensions.cs
+++ b/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticExtensions.cs
@@ -308,6 +308,44 @@ public static class NatsPcgElasticExtensions
     }
 
     /// <summary>
+    /// Adds partitioning filters to an elastic consumer group.
+    /// </summary>
+    /// <param name="js">JetStream context.</param>
+    /// <param name="streamName">Name of the source stream.</param>
+    /// <param name="consumerGroupName">Name of the consumer group.</param>
+    /// <param name="partitioningFiltersToAdd">Partitioning filters to add.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Updated partitioning filters.</returns>
+    public static async Task<NatsPcgPartitioningFilter[]> AddPcgElasticFiltersAsync(
+        this INatsJSContext js,
+        string streamName,
+        string consumerGroupName,
+        NatsPcgPartitioningFilter[] partitioningFiltersToAdd,
+        CancellationToken cancellationToken = default)
+    {
+        return await UpdateFiltersAsync(js, streamName, consumerGroupName, partitioningFiltersToAdd, add: true, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Removes partitioning filters from an elastic consumer group.
+    /// </summary>
+    /// <param name="js">JetStream context.</param>
+    /// <param name="streamName">Name of the source stream.</param>
+    /// <param name="consumerGroupName">Name of the consumer group.</param>
+    /// <param name="partitioningFiltersToDrop">Partitioning filters to remove.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Updated partitioning filters.</returns>
+    public static async Task<NatsPcgPartitioningFilter[]> DeletePcgElasticFiltersAsync(
+        this INatsJSContext js,
+        string streamName,
+        string consumerGroupName,
+        NatsPcgPartitioningFilter[] partitioningFiltersToDrop,
+        CancellationToken cancellationToken = default)
+    {
+        return await UpdateFiltersAsync(js, streamName, consumerGroupName, partitioningFiltersToDrop, add: false, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Sets custom member-to-partition mappings.
     /// </summary>
     /// <param name="js">JetStream context.</param>
@@ -525,6 +563,23 @@ public static class NatsPcgElasticExtensions
         NatsPcgElasticConfig config,
         CancellationToken cancellationToken)
     {
+        var streamConfig = BuildWorkQueueStreamConfig(streamName, consumerGroupName, config);
+        await js.CreateStreamAsync(streamConfig, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task UpdateWorkQueueStreamAsync(
+        INatsJSContext js,
+        string streamName,
+        string consumerGroupName,
+        NatsPcgElasticConfig config,
+        CancellationToken cancellationToken)
+    {
+        var streamConfig = BuildWorkQueueStreamConfig(streamName, consumerGroupName, config);
+        await js.CreateOrUpdateStreamAsync(streamConfig, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static StreamConfig BuildWorkQueueStreamConfig(string streamName, string consumerGroupName, NatsPcgElasticConfig config)
+    {
         string workQueueStreamName = GetWorkQueueStreamName(streamName, consumerGroupName);
 
         var subjectTransforms = new List<SubjectTransform>();
@@ -567,7 +622,7 @@ public static class NatsPcgElasticExtensions
             streamConfig.MaxBytes = config.MaxBufferedBytes.Value;
         }
 
-        await js.CreateStreamAsync(streamConfig, cancellationToken).ConfigureAwait(false);
+        return streamConfig;
     }
 
     private static SubjectTransform BuildSubjectTransform(NatsPcgPartitioningFilter pf, uint maxMembers)
@@ -665,6 +720,91 @@ public static class NatsPcgElasticExtensions
             {
                 await store.UpdateAsync(key, updatedConfig, entry.Revision, serializer: NatsPcgJsonSerializer<NatsPcgElasticConfig>.Default, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return updatedMembers ?? Array.Empty<string>();
+            }
+            catch (NatsKVWrongLastRevisionException)
+            {
+                // Config changed - retry
+                if (retry < maxRetries - 1)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(50 * (retry + 1)), cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        throw new NatsPcgException("Failed to update config after maximum retries");
+    }
+
+    private static async Task<NatsPcgPartitioningFilter[]> UpdateFiltersAsync(
+        INatsJSContext js,
+        string streamName,
+        string consumerGroupName,
+        NatsPcgPartitioningFilter[] partitioningFilters,
+        bool add,
+        CancellationToken cancellationToken)
+    {
+        if (partitioningFilters == null)
+        {
+            throw new ArgumentNullException(nameof(partitioningFilters));
+        }
+
+        var kv = js.Connection.CreateKeyValueStoreContext();
+        var store = await kv.GetStoreAsync(NatsPcgConstants.ElasticKvBucket, cancellationToken).ConfigureAwait(false);
+        string key = GetKvKey(streamName, consumerGroupName);
+
+        // Retry loop for optimistic concurrency
+        const int maxRetries = 5;
+        for (int retry = 0; retry < maxRetries; retry++)
+        {
+            var entry = await store.GetEntryAsync(key, serializer: NatsPcgJsonSerializer<NatsPcgElasticConfig>.Default, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (entry.Value == null)
+            {
+                throw new NatsPcgException($"Consumer group '{consumerGroupName}' not found");
+            }
+
+            var config = entry.Value;
+            var updatedFilters = new SortedSet<NatsPcgPartitioningFilter>(config.PartitioningFilters, PartitioningFilterComparer.Instance);
+            var originalCount = updatedFilters.Count;
+
+            if (add)
+            {
+                foreach (var filter in partitioningFilters)
+                {
+                    updatedFilters.Add(filter);
+                }
+            }
+            else
+            {
+                foreach (var filter in partitioningFilters)
+                {
+                    updatedFilters.Remove(filter);
+                }
+            }
+
+            if (updatedFilters.Count == originalCount)
+            {
+                return config.PartitioningFilters;
+            }
+
+            if (updatedFilters.Count == 0)
+            {
+                throw new NatsPcgConfigurationException("At least one partitioning filter must be specified");
+            }
+
+            var filtersArray = updatedFilters.ToArray();
+            NatsPcgMemberMappingValidator.ValidatePartitioningFilters(filtersArray);
+
+            var updatedConfig = config with
+            {
+                PartitioningFilters = filtersArray,
+            };
+
+            // Keep work-queue stream source transforms in sync with config partitioning filters.
+            await UpdateWorkQueueStreamAsync(js, streamName, consumerGroupName, updatedConfig, cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                await store.UpdateAsync(key, updatedConfig, entry.Revision, serializer: NatsPcgJsonSerializer<NatsPcgElasticConfig>.Default, cancellationToken: cancellationToken).ConfigureAwait(false);
+                return filtersArray;
             }
             catch (NatsKVWrongLastRevisionException)
             {

--- a/src/Synadia.Orbit.PCGroups/NatsPcgPartitioningFilter.cs
+++ b/src/Synadia.Orbit.PCGroups/NatsPcgPartitioningFilter.cs
@@ -33,4 +33,101 @@ public sealed record NatsPcgPartitioningFilter
     /// </summary>
     [JsonPropertyName("partitioning_wildcards")]
     public int[] PartitioningWildcards { get; init; }
+
+    /// <inheritdoc />
+    public bool Equals(NatsPcgPartitioningFilter? other)
+    {
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (!string.Equals(Filter, other.Filter, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var leftWildcards = PartitioningWildcards ?? Array.Empty<int>();
+        var rightWildcards = other.PartitioningWildcards ?? Array.Empty<int>();
+
+        if (leftWildcards.Length != rightWildcards.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < leftWildcards.Length; i++)
+        {
+            if (leftWildcards[i] != rightWildcards[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            int hash = StringComparer.Ordinal.GetHashCode(Filter ?? string.Empty);
+            var wildcards = PartitioningWildcards ?? Array.Empty<int>();
+            for (int i = 0; i < wildcards.Length; i++)
+            {
+                hash = (hash * 397) ^ wildcards[i];
+            }
+
+            return hash;
+        }
+    }
+}
+
+internal sealed class PartitioningFilterComparer : IComparer<NatsPcgPartitioningFilter>
+{
+    internal static readonly PartitioningFilterComparer Instance = new();
+
+    public int Compare(NatsPcgPartitioningFilter? x, NatsPcgPartitioningFilter? y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return 0;
+        }
+
+        if (x is null)
+        {
+            return -1;
+        }
+
+        if (y is null)
+        {
+            return 1;
+        }
+
+        int filterCompare = string.Compare(x.Filter, y.Filter, StringComparison.Ordinal);
+        if (filterCompare != 0)
+        {
+            return filterCompare;
+        }
+
+        var xWildcards = x.PartitioningWildcards ?? Array.Empty<int>();
+        var yWildcards = y.PartitioningWildcards ?? Array.Empty<int>();
+
+        int minLength = Math.Min(xWildcards.Length, yWildcards.Length);
+        for (int i = 0; i < minLength; i++)
+        {
+            int wildcardCompare = xWildcards[i].CompareTo(yWildcards[i]);
+            if (wildcardCompare != 0)
+            {
+                return wildcardCompare;
+            }
+        }
+
+        return xWildcards.Length.CompareTo(yWildcards.Length);
+    }
 }

--- a/src/Synadia.Orbit.PCGroups/PACKAGE.md
+++ b/src/Synadia.Orbit.PCGroups/PACKAGE.md
@@ -216,6 +216,8 @@ Example: For `orders.*` with transform `{{partition(3,1)}}.orders.{{wildcard(1)}
 - `ListPcgElasticActiveMembersAsync` - List active members
 - `AddPcgElasticMembersAsync` - Add members to the group
 - `DeletePcgElasticMembersAsync` - Remove members from the group
+- `AddPcgElasticFiltersAsync` - Add partitioning filters to the group
+- `DeletePcgElasticFiltersAsync` - Remove partitioning filters from the group
 - `SetPcgElasticMemberMappingsAsync` - Set explicit partition mappings
 - `DeletePcgElasticMemberMappingsAsync` - Remove mappings (revert to auto-distribution)
 - `IsInPcgElasticMembershipAndActiveAsync` - Check if a member is in the group and active

--- a/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
@@ -116,6 +116,136 @@ public class NatsPcgElasticExtensionsTests
     }
 
     [Fact]
+    public async Task AddAndRemoveFilters_Success()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var js = nats.CreateJetStreamContext();
+
+        var streamName = $"test-stream-{Guid.NewGuid():N}";
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = new[] { "orders.*", "refunds.*" },
+        });
+
+        try
+        {
+            var groupName = $"test-group-{Guid.NewGuid():N}";
+            await js.CreatePcgElasticAsync(
+                streamName,
+                groupName,
+                maxNumMembers: 3,
+                partitioningFilters: [new NatsPcgPartitioningFilter("orders.*", [1])]);
+
+            var filters = await js.AddPcgElasticFiltersAsync(streamName, groupName, [
+                new NatsPcgPartitioningFilter("refunds.*", [1]),
+                new NatsPcgPartitioningFilter("orders.*", [1]),
+            ]);
+            Assert.Equal(2, filters.Length);
+            Assert.Equal("orders.*", filters[0].Filter);
+            Assert.Equal(new[] { 1 }, filters[0].PartitioningWildcards);
+            Assert.Equal("refunds.*", filters[1].Filter);
+            Assert.Equal(new[] { 1 }, filters[1].PartitioningWildcards);
+
+            var config = await js.GetPcgElasticConfigAsync(streamName, groupName);
+            Assert.Equal(2, config.PartitioningFilters.Length);
+            Assert.Equal("orders.*", config.PartitioningFilters[0].Filter);
+            Assert.Equal(new[] { 1 }, config.PartitioningFilters[0].PartitioningWildcards);
+            Assert.Equal("refunds.*", config.PartitioningFilters[1].Filter);
+            Assert.Equal(new[] { 1 }, config.PartitioningFilters[1].PartitioningWildcards);
+
+            var workQueueStreamName = $"{streamName}-{groupName}";
+            var workQueueStream = await js.GetStreamAsync(workQueueStreamName);
+            var source = Assert.Single(workQueueStream.Info.Config.Sources!);
+            var sourceFilters = source.SubjectTransforms!.Select(x => x.Src).ToArray();
+            Assert.Equal(new[] { "orders.*", "refunds.*" }, sourceFilters);
+
+            filters = await js.DeletePcgElasticFiltersAsync(streamName, groupName, [new NatsPcgPartitioningFilter("orders.*", [1])]);
+            Assert.Single(filters);
+            Assert.Equal("refunds.*", filters[0].Filter);
+            Assert.Equal(new[] { 1 }, filters[0].PartitioningWildcards);
+
+            config = await js.GetPcgElasticConfigAsync(streamName, groupName);
+            Assert.Single(config.PartitioningFilters);
+            Assert.Equal("refunds.*", config.PartitioningFilters[0].Filter);
+            Assert.Equal(new[] { 1 }, config.PartitioningFilters[0].PartitioningWildcards);
+
+            workQueueStream = await js.GetStreamAsync(workQueueStreamName);
+            source = Assert.Single(workQueueStream.Info.Config.Sources!);
+            sourceFilters = source.SubjectTransforms!.Select(x => x.Src).ToArray();
+            Assert.Equal(new[] { "refunds.*" }, sourceFilters);
+
+            await js.DeletePcgElasticAsync(streamName, groupName);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    [Fact]
+    public async Task Validation_CannotRemoveAllFilters()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var js = nats.CreateJetStreamContext();
+
+        var streamName = $"test-stream-{Guid.NewGuid():N}";
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = new[] { "orders.>" },
+        });
+
+        try
+        {
+            var groupName = $"test-group-{Guid.NewGuid():N}";
+            await js.CreatePcgElasticAsync(streamName, groupName, 3, [new NatsPcgPartitioningFilter("orders.*", [1])]);
+
+            var exception = await Assert.ThrowsAsync<NatsPcgConfigurationException>(() =>
+                js.DeletePcgElasticFiltersAsync(streamName, groupName, [new NatsPcgPartitioningFilter("orders.*", [1])]));
+
+            Assert.Contains("At least one partitioning filter", exception.Message);
+
+            await js.DeletePcgElasticAsync(streamName, groupName);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    [Fact]
+    public async Task Validation_AddInvalidFilter_ThrowsException()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var js = nats.CreateJetStreamContext();
+
+        var streamName = $"test-stream-{Guid.NewGuid():N}";
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = new[] { "orders.>", "refunds.>" },
+        });
+
+        try
+        {
+            var groupName = $"test-group-{Guid.NewGuid():N}";
+            await js.CreatePcgElasticAsync(streamName, groupName, 3, [new NatsPcgPartitioningFilter("orders.*", [1])]);
+
+            var exception = await Assert.ThrowsAsync<NatsPcgConfigurationException>(() =>
+                js.AddPcgElasticFiltersAsync(streamName, groupName, [new NatsPcgPartitioningFilter("refunds.>", [1])]));
+
+            Assert.Contains("wildcard", exception.Message);
+
+            await js.DeletePcgElasticAsync(streamName, groupName);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    [Fact]
     public async Task SetMemberMappings_Success()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });


### PR DESCRIPTION
This PR adds runtime partitioning-filter management for Elastic PCGroups and fixes NatsPcgPartitioningFilter value semantics.

Changes
Added:
AddPcgElasticFiltersAsync(...)
DeletePcgElasticFiltersAsync(...)
NatsPcgPartitioningFilter now compares by value (Filter + PartitioningWildcards) via custom Equals/GetHashCode.