### PR TITLE
Add helper to delete elastic work queue consumers

### DIFF
--- a/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticExtensions.cs
+++ b/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticExtensions.cs
@@ -189,6 +189,33 @@ public static class NatsPcgElasticExtensions
     }
 
     /// <summary>
+    /// Deletes a work-queue consumer for an elastic consumer group member.
+    /// </summary>
+    /// <param name="js">JetStream context.</param>
+    /// <param name="streamName">Name of the source stream.</param>
+    /// <param name="consumerGroupName">Name of the consumer group.</param>
+    /// <param name="memberName">Name of the member whose work-queue consumer should be deleted.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public static async Task DeletePcgElasticWorkQueueConsumerAsync(
+        this INatsJSContext js,
+        string streamName,
+        string consumerGroupName,
+        string memberName,
+        CancellationToken cancellationToken = default)
+    {
+        string workQueueStreamName = GetWorkQueueStreamName(streamName, consumerGroupName);
+
+        try
+        {
+            await js.DeleteConsumerAsync(workQueueStreamName, memberName, cancellationToken).ConfigureAwait(false);
+        }
+        catch (NatsJSApiException ex) when (ex.Error.Code == 404)
+        {
+            // Consumer already deleted - ignore
+        }
+    }
+
+    /// <summary>
     /// Lists all elastic consumer groups for a stream.
     /// </summary>
     /// <param name="js">JetStream context.</param>

--- a/src/Synadia.Orbit.PCGroups/PACKAGE.md
+++ b/src/Synadia.Orbit.PCGroups/PACKAGE.md
@@ -212,6 +212,7 @@ Example: For `orders.*` with transform `{{partition(3,1)}}.orders.{{wildcard(1)}
 - `GetPcgElasticConfigAsync` - Get configuration for an existing group
 - `ConsumePcgElasticAsync` - Start consuming messages (returns `IAsyncEnumerable<NatsPcgMsg<T>>`)
 - `DeletePcgElasticAsync` - Delete a consumer group and its work-queue stream
+- `DeletePcgElasticWorkQueueConsumerAsync` - Delete a member's work-queue consumer
 - `ListPcgElasticAsync` - List all consumer groups for a stream
 - `ListPcgElasticActiveMembersAsync` - List active members
 - `AddPcgElasticMembersAsync` - Add members to the group


### PR DESCRIPTION
Add `DeletePcgElasticWorkQueueConsumerAsync` to support faster recovery when using ephemeral member name.

Keep `DeletePcgElasticMembersAsync` unchanged so its behavior remains consistent with similar APIs in other language clients.