### PR TITLE
Retry ports file parse on empty read

### DIFF
--- a/src/Synadia.Orbit.Testing.NatsServerProcessManager/NatsServerProcess.cs
+++ b/src/Synadia.Orbit.Testing.NatsServerProcessManager/NatsServerProcess.cs
@@ -142,13 +142,14 @@ public class NatsServerProcess : IAsyncDisposable, IDisposable
         var portsFile = Path.Combine(portsFileDir, $"{natsServerExe}_{process.Id}.ports");
         log($"portsFile={portsFile}");
 
-        string? ports = null;
+        JsonDocument? portsJson = null;
         Exception? exception = null;
         for (var i = 0; i < 10; i++)
         {
             try
             {
-                ports = File.ReadAllText(portsFile);
+                var content = File.ReadAllText(portsFile);
+                portsJson = JsonDocument.Parse(content);
                 break;
             }
             catch (Exception e)
@@ -158,15 +159,14 @@ public class NatsServerProcess : IAsyncDisposable, IDisposable
             }
         }
 
-        if (ports == null)
+        if (portsJson == null)
         {
             throw new Exception("Failed to read ports file", exception);
         }
 
-        using var portsJson = JsonDocument.Parse(ports);
+        using var disposePortsJson = portsJson;
         var url = new Uri(portsJson.RootElement.GetProperty("nats")[0].GetString()!);
         var monitorUrl = new Uri(portsJson.RootElement.GetProperty("monitoring")[0].GetString()!);
-        log($"ports={ports}");
         log($"url={url}");
         log($"monitorUrl={monitorUrl}");
 


### PR DESCRIPTION
nats-server creates the ports file before writing JSON, so the retry loop in `NatsServerProcess.StartAsync` could successfully read an empty/partial file and then throw `JsonReaderException` on `JsonDocument.Parse`. Moves the parse inside the retry loop so empty reads trigger a retry instead of failing the test. Observed intermittently in nats.net CI on Linux v2.11.