### PR TITLE
Release NatsServerProcessManager 1.0.0-preview.4

### DIFF
--- a/src/Synadia.Orbit.Testing.NatsServerProcessManager/version.txt
+++ b/src/Synadia.Orbit.Testing.NatsServerProcessManager/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.3
+1.0.0-preview.4


### PR DESCRIPTION
Bumps NatsServerProcessManager to 1.0.0-preview.4. Changes since preview.3:

- tests: retry ports file parse on empty read (#50)