### PR TITLE
Release JetStream.Publisher 1.0.0-preview.4

### DIFF
--- a/src/Synadia.Orbit.JetStream.Publisher/version.txt
+++ b/src/Synadia.Orbit.JetStream.Publisher/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.3
+1.0.0-preview.4


### PR DESCRIPTION
Bump Synadia.Orbit.JetStream.Publisher to 1.0.0-preview.4. Adds atomic batch publishing (requires NATS server v2.12+).

- Add JetStream batch publishing (#10)