### PR TITLE
Make batch publisher payload generic

### DIFF
--- a/src/Synadia.Orbit.JetStream.Publisher/INatsJSBatchPublisher.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/INatsJSBatchPublisher.cs
@@ -9,11 +9,18 @@ namespace Synadia.Orbit.JetStream.Publisher;
 /// Provides methods for publishing messages to a stream in batches.
 /// </summary>
 /// <remarks>
-/// Disposing without calling <see cref="CommitAsync{T}(string,T,NatsJSBatchMsgOpts,INatsSerialize{T},CancellationToken)"/>
-/// or <see cref="CommitMsgAsync{T}(NatsMsg{T},NatsJSBatchMsgOpts,INatsSerialize{T},CancellationToken)"/> closes the
-/// publisher locally but leaves any already-sent messages as an incomplete batch on the server
-/// until the server's batch timeout expires. Call <see cref="Discard"/> or commit before disposal
-/// to make the intent explicit.
+/// <para>
+/// Disposing without calling <c>CommitAsync</c> or <c>CommitMsgAsync</c> closes the publisher
+/// locally but leaves any already-sent messages as an incomplete batch on the server until the
+/// server's batch timeout expires. Call <see cref="Discard"/> or commit before disposal to make
+/// the intent explicit.
+/// </para>
+/// <para>
+/// If a payload's value implements <see cref="IDisposable"/> (for example
+/// <see cref="NatsMemoryOwner{T}"/> or any <see cref="System.Buffers.IMemoryOwner{T}"/>),
+/// ownership transfers to the publisher: the buffer is disposed after the bytes are written to
+/// the wire, or on any pre-publish throw.
+/// </para>
 /// </remarks>
 public interface INatsJSBatchPublisher : IAsyncDisposable
 {
@@ -32,17 +39,15 @@ public interface INatsJSBatchPublisher : IAsyncDisposable
     /// </summary>
     /// <typeparam name="T">The payload type. Resolved by the configured serializer or by an explicit <paramref name="serializer"/>.</typeparam>
     /// <param name="subject">The subject to publish the message to.</param>
-    /// <param name="data">The message data. If the value implements <see cref="IDisposable"/> (e.g. <see cref="NatsMemoryOwner{T}"/> or any <see cref="System.Buffers.IMemoryOwner{T}"/>), ownership transfers to the publisher: the buffer is disposed after the bytes are written to the wire, or on any pre-publish throw.</param>
+    /// <param name="data">The message data. See remarks on <see cref="INatsJSBatchPublisher"/> for ownership semantics.</param>
     /// <param name="opts">Optional per-message options.</param>
     /// <param name="serializer">Optional serializer for the payload. When null, the connection's registered serializer is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     /// <remarks>
     /// When flow control is disabled (<see cref="NatsJSBatchFlowControl.AckFirst"/> is false and
-    /// <see cref="NatsJSBatchFlowControl.AckEvery"/> is 0), this method publishes fire-and-forget.
-    /// Server-side errors for individual messages are not observed until
-    /// <see cref="CommitAsync{T}(string,T,NatsJSBatchMsgOpts,INatsSerialize{T},CancellationToken)"/> /
-    /// <see cref="CommitMsgAsync{T}(NatsMsg{T},NatsJSBatchMsgOpts,INatsSerialize{T},CancellationToken)"/> is called.
+    /// <see cref="NatsJSBatchFlowControl.AckEvery"/> is 0), this method publishes fire-and-forget;
+    /// server-side errors for individual messages are not observed until commit.
     /// </remarks>
     Task AddAsync<T>(string subject, T data, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default);
 
@@ -50,17 +55,15 @@ public interface INatsJSBatchPublisher : IAsyncDisposable
     /// Publishes a message to the batch.
     /// </summary>
     /// <typeparam name="T">The payload type. Resolved by the configured serializer or by an explicit <paramref name="serializer"/>.</typeparam>
-    /// <param name="msg">The message to publish. If <see cref="NatsMsg{T}.Data"/> implements <see cref="IDisposable"/> (e.g. <see cref="NatsMemoryOwner{T}"/> or any <see cref="System.Buffers.IMemoryOwner{T}"/>), ownership transfers to the publisher: the buffer is disposed after the bytes are written to the wire, or on any pre-publish throw.</param>
+    /// <param name="msg">The message to publish. See remarks on <see cref="INatsJSBatchPublisher"/> for ownership semantics.</param>
     /// <param name="opts">Optional per-message options.</param>
     /// <param name="serializer">Optional serializer for the payload. When null, the connection's registered serializer is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     /// <remarks>
     /// When flow control is disabled (<see cref="NatsJSBatchFlowControl.AckFirst"/> is false and
-    /// <see cref="NatsJSBatchFlowControl.AckEvery"/> is 0), this method publishes fire-and-forget.
-    /// Server-side errors for individual messages are not observed until
-    /// <see cref="CommitAsync{T}(string,T,NatsJSBatchMsgOpts,INatsSerialize{T},CancellationToken)"/> /
-    /// <see cref="CommitMsgAsync{T}(NatsMsg{T},NatsJSBatchMsgOpts,INatsSerialize{T},CancellationToken)"/> is called.
+    /// <see cref="NatsJSBatchFlowControl.AckEvery"/> is 0), this method publishes fire-and-forget;
+    /// server-side errors for individual messages are not observed until commit.
     /// </remarks>
     Task AddMsgAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default);
 
@@ -69,7 +72,7 @@ public interface INatsJSBatchPublisher : IAsyncDisposable
     /// </summary>
     /// <typeparam name="T">The payload type. Resolved by the configured serializer or by an explicit <paramref name="serializer"/>.</typeparam>
     /// <param name="subject">The subject to publish the message to.</param>
-    /// <param name="data">The message data. If the value implements <see cref="IDisposable"/> (e.g. <see cref="NatsMemoryOwner{T}"/> or any <see cref="System.Buffers.IMemoryOwner{T}"/>), ownership transfers to the publisher: the buffer is disposed after the bytes are written to the wire, or on any pre-publish throw.</param>
+    /// <param name="data">The message data. See remarks on <see cref="INatsJSBatchPublisher"/> for ownership semantics.</param>
     /// <param name="opts">Optional per-message options.</param>
     /// <param name="serializer">Optional serializer for the payload. When null, the connection's registered serializer is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
@@ -78,8 +81,7 @@ public interface INatsJSBatchPublisher : IAsyncDisposable
     /// If a <see cref="TimeoutException"/> or <see cref="OperationCanceledException"/> is thrown
     /// after the commit request was sent, the batch may or may not have been persisted; the ack
     /// may simply have been lost. There is no idempotency key for commits, so callers should
-    /// check the stream's last sequence to determine whether the batch was actually written before
-    /// retrying.
+    /// check the stream's last sequence before retrying.
     /// </remarks>
     Task<NatsJSBatchAck> CommitAsync<T>(string subject, T data, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default);
 
@@ -87,7 +89,7 @@ public interface INatsJSBatchPublisher : IAsyncDisposable
     /// Publishes the final message and commits the batch.
     /// </summary>
     /// <typeparam name="T">The payload type. Resolved by the configured serializer or by an explicit <paramref name="serializer"/>.</typeparam>
-    /// <param name="msg">The message to publish. If <see cref="NatsMsg{T}.Data"/> implements <see cref="IDisposable"/> (e.g. <see cref="NatsMemoryOwner{T}"/> or any <see cref="System.Buffers.IMemoryOwner{T}"/>), ownership transfers to the publisher: the buffer is disposed after the bytes are written to the wire, or on any pre-publish throw.</param>
+    /// <param name="msg">The message to publish. See remarks on <see cref="INatsJSBatchPublisher"/> for ownership semantics.</param>
     /// <param name="opts">Optional per-message options.</param>
     /// <param name="serializer">Optional serializer for the payload. When null, the connection's registered serializer is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
@@ -96,8 +98,7 @@ public interface INatsJSBatchPublisher : IAsyncDisposable
     /// If a <see cref="TimeoutException"/> or <see cref="OperationCanceledException"/> is thrown
     /// after the commit request was sent, the batch may or may not have been persisted; the ack
     /// may simply have been lost. There is no idempotency key for commits, so callers should
-    /// check the stream's last sequence to determine whether the batch was actually written before
-    /// retrying.
+    /// check the stream's last sequence before retrying.
     /// </remarks>
     Task<NatsJSBatchAck> CommitMsgAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default);
 

--- a/src/Synadia.Orbit.JetStream.Publisher/INatsJSBatchPublisher.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/INatsJSBatchPublisher.cs
@@ -9,7 +9,8 @@ namespace Synadia.Orbit.JetStream.Publisher;
 /// Provides methods for publishing messages to a stream in batches.
 /// </summary>
 /// <remarks>
-/// Disposing without calling <see cref="CommitAsync"/> or <see cref="CommitMsgAsync"/> closes the
+/// Disposing without calling <see cref="CommitAsync(string,byte[],NatsJSBatchMsgOpts,CancellationToken)"/>
+/// or <see cref="CommitMsgAsync(NatsMsg{byte[]},NatsJSBatchMsgOpts,CancellationToken)"/> closes the
 /// publisher locally but leaves any already-sent messages as an incomplete batch on the server
 /// until the server's batch timeout expires. Call <see cref="Discard"/> or commit before disposal
 /// to make the intent explicit.
@@ -38,9 +39,27 @@ public interface INatsJSBatchPublisher : IAsyncDisposable
     /// When flow control is disabled (<see cref="NatsJSBatchFlowControl.AckFirst"/> is false and
     /// <see cref="NatsJSBatchFlowControl.AckEvery"/> is 0), this method publishes fire-and-forget.
     /// Server-side errors for individual messages are not observed until
-    /// <see cref="CommitAsync"/>/<see cref="CommitMsgAsync"/> is called.
+    /// <see cref="CommitAsync(string,byte[],NatsJSBatchMsgOpts,CancellationToken)"/> /
+    /// <see cref="CommitMsgAsync(NatsMsg{byte[]},NatsJSBatchMsgOpts,CancellationToken)"/> is called.
     /// </remarks>
     Task AddAsync(string subject, byte[] data, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Publishes a message to the batch with the given subject and data using a pooled buffer.
+    /// </summary>
+    /// <param name="subject">The subject to publish the message to.</param>
+    /// <param name="data">The message data. Ownership transfers to the publisher: the buffer is disposed after the bytes are written to the wire.</param>
+    /// <param name="opts">Optional per-message options.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// When flow control is disabled (<see cref="NatsJSBatchFlowControl.AckFirst"/> is false and
+    /// <see cref="NatsJSBatchFlowControl.AckEvery"/> is 0), this method publishes fire-and-forget.
+    /// Server-side errors for individual messages are not observed until
+    /// <see cref="CommitAsync(string,NatsMemoryOwner{byte},NatsJSBatchMsgOpts,CancellationToken)"/> /
+    /// <see cref="CommitMsgAsync(NatsMsg{NatsMemoryOwner{byte}},NatsJSBatchMsgOpts,CancellationToken)"/> is called.
+    /// </remarks>
+    Task AddAsync(string subject, NatsMemoryOwner<byte> data, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Publishes a message to the batch.
@@ -53,9 +72,26 @@ public interface INatsJSBatchPublisher : IAsyncDisposable
     /// When flow control is disabled (<see cref="NatsJSBatchFlowControl.AckFirst"/> is false and
     /// <see cref="NatsJSBatchFlowControl.AckEvery"/> is 0), this method publishes fire-and-forget.
     /// Server-side errors for individual messages are not observed until
-    /// <see cref="CommitAsync"/>/<see cref="CommitMsgAsync"/> is called.
+    /// <see cref="CommitAsync(string,byte[],NatsJSBatchMsgOpts,CancellationToken)"/> /
+    /// <see cref="CommitMsgAsync(NatsMsg{byte[]},NatsJSBatchMsgOpts,CancellationToken)"/> is called.
     /// </remarks>
     Task AddMsgAsync(NatsMsg<byte[]> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Publishes a message to the batch using a pooled buffer payload.
+    /// </summary>
+    /// <param name="msg">The message to publish. Ownership of <see cref="NatsMsg{T}.Data"/> transfers to the publisher: the buffer is disposed after the bytes are written to the wire.</param>
+    /// <param name="opts">Optional per-message options.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// When flow control is disabled (<see cref="NatsJSBatchFlowControl.AckFirst"/> is false and
+    /// <see cref="NatsJSBatchFlowControl.AckEvery"/> is 0), this method publishes fire-and-forget.
+    /// Server-side errors for individual messages are not observed until
+    /// <see cref="CommitAsync(string,NatsMemoryOwner{byte},NatsJSBatchMsgOpts,CancellationToken)"/> /
+    /// <see cref="CommitMsgAsync(NatsMsg{NatsMemoryOwner{byte}},NatsJSBatchMsgOpts,CancellationToken)"/> is called.
+    /// </remarks>
+    Task AddMsgAsync(NatsMsg<NatsMemoryOwner<byte>> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Publishes the final message with the given subject and data, and commits the batch.
@@ -75,6 +111,23 @@ public interface INatsJSBatchPublisher : IAsyncDisposable
     Task<NatsJSBatchAck> CommitAsync(string subject, byte[] data, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Publishes the final message with the given subject and data using a pooled buffer, and commits the batch.
+    /// </summary>
+    /// <param name="subject">The subject to publish the message to.</param>
+    /// <param name="data">The message data. Ownership transfers to the publisher: the buffer is disposed after the bytes are written to the wire.</param>
+    /// <param name="opts">Optional per-message options.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task containing the batch acknowledgment.</returns>
+    /// <remarks>
+    /// If a <see cref="TimeoutException"/> or <see cref="OperationCanceledException"/> is thrown
+    /// after the commit request was sent, the batch may or may not have been persisted; the ack
+    /// may simply have been lost. There is no idempotency key for commits, so callers should
+    /// check the stream's last sequence to determine whether the batch was actually written before
+    /// retrying.
+    /// </remarks>
+    Task<NatsJSBatchAck> CommitAsync(string subject, NatsMemoryOwner<byte> data, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Publishes the final message and commits the batch.
     /// </summary>
     /// <param name="msg">The message to publish.</param>
@@ -89,6 +142,22 @@ public interface INatsJSBatchPublisher : IAsyncDisposable
     /// retrying.
     /// </remarks>
     Task<NatsJSBatchAck> CommitMsgAsync(NatsMsg<byte[]> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Publishes the final message using a pooled buffer payload and commits the batch.
+    /// </summary>
+    /// <param name="msg">The message to publish. Ownership of <see cref="NatsMsg{T}.Data"/> transfers to the publisher: the buffer is disposed after the bytes are written to the wire.</param>
+    /// <param name="opts">Optional per-message options.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task containing the batch acknowledgment.</returns>
+    /// <remarks>
+    /// If a <see cref="TimeoutException"/> or <see cref="OperationCanceledException"/> is thrown
+    /// after the commit request was sent, the batch may or may not have been persisted; the ack
+    /// may simply have been lost. There is no idempotency key for commits, so callers should
+    /// check the stream's last sequence to determine whether the batch was actually written before
+    /// retrying.
+    /// </remarks>
+    Task<NatsJSBatchAck> CommitMsgAsync(NatsMsg<NatsMemoryOwner<byte>> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Cancels the batch without committing.

--- a/src/Synadia.Orbit.JetStream.Publisher/INatsJSBatchPublisher.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/INatsJSBatchPublisher.cs
@@ -9,8 +9,8 @@ namespace Synadia.Orbit.JetStream.Publisher;
 /// Provides methods for publishing messages to a stream in batches.
 /// </summary>
 /// <remarks>
-/// Disposing without calling <see cref="CommitAsync(string,byte[],NatsJSBatchMsgOpts,CancellationToken)"/>
-/// or <see cref="CommitMsgAsync(NatsMsg{byte[]},NatsJSBatchMsgOpts,CancellationToken)"/> closes the
+/// Disposing without calling <see cref="CommitAsync{T}(string,T,NatsJSBatchMsgOpts,INatsSerialize{T},CancellationToken)"/>
+/// or <see cref="CommitMsgAsync{T}(NatsMsg{T},NatsJSBatchMsgOpts,INatsSerialize{T},CancellationToken)"/> closes the
 /// publisher locally but leaves any already-sent messages as an incomplete batch on the server
 /// until the server's batch timeout expires. Call <see cref="Discard"/> or commit before disposal
 /// to make the intent explicit.
@@ -30,75 +30,48 @@ public interface INatsJSBatchPublisher : IAsyncDisposable
     /// <summary>
     /// Publishes a message to the batch with the given subject and data.
     /// </summary>
+    /// <typeparam name="T">The payload type. Resolved by the configured serializer or by an explicit <paramref name="serializer"/>.</typeparam>
     /// <param name="subject">The subject to publish the message to.</param>
-    /// <param name="data">The message data.</param>
+    /// <param name="data">The message data. If the value implements <see cref="IDisposable"/> (e.g. <see cref="NatsMemoryOwner{T}"/> or any <see cref="System.Buffers.IMemoryOwner{T}"/>), ownership transfers to the publisher: the buffer is disposed after the bytes are written to the wire, or on any pre-publish throw.</param>
     /// <param name="opts">Optional per-message options.</param>
+    /// <param name="serializer">Optional serializer for the payload. When null, the connection's registered serializer is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     /// <remarks>
     /// When flow control is disabled (<see cref="NatsJSBatchFlowControl.AckFirst"/> is false and
     /// <see cref="NatsJSBatchFlowControl.AckEvery"/> is 0), this method publishes fire-and-forget.
     /// Server-side errors for individual messages are not observed until
-    /// <see cref="CommitAsync(string,byte[],NatsJSBatchMsgOpts,CancellationToken)"/> /
-    /// <see cref="CommitMsgAsync(NatsMsg{byte[]},NatsJSBatchMsgOpts,CancellationToken)"/> is called.
+    /// <see cref="CommitAsync{T}(string,T,NatsJSBatchMsgOpts,INatsSerialize{T},CancellationToken)"/> /
+    /// <see cref="CommitMsgAsync{T}(NatsMsg{T},NatsJSBatchMsgOpts,INatsSerialize{T},CancellationToken)"/> is called.
     /// </remarks>
-    Task AddAsync(string subject, byte[] data, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Publishes a message to the batch with the given subject and data using a pooled buffer.
-    /// </summary>
-    /// <param name="subject">The subject to publish the message to.</param>
-    /// <param name="data">The message data. Ownership transfers to the publisher: the buffer is disposed after the bytes are written to the wire.</param>
-    /// <param name="opts">Optional per-message options.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
-    /// <remarks>
-    /// When flow control is disabled (<see cref="NatsJSBatchFlowControl.AckFirst"/> is false and
-    /// <see cref="NatsJSBatchFlowControl.AckEvery"/> is 0), this method publishes fire-and-forget.
-    /// Server-side errors for individual messages are not observed until
-    /// <see cref="CommitAsync(string,NatsMemoryOwner{byte},NatsJSBatchMsgOpts,CancellationToken)"/> /
-    /// <see cref="CommitMsgAsync(NatsMsg{NatsMemoryOwner{byte}},NatsJSBatchMsgOpts,CancellationToken)"/> is called.
-    /// </remarks>
-    Task AddAsync(string subject, NatsMemoryOwner<byte> data, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default);
+    Task AddAsync<T>(string subject, T data, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Publishes a message to the batch.
     /// </summary>
-    /// <param name="msg">The message to publish.</param>
+    /// <typeparam name="T">The payload type. Resolved by the configured serializer or by an explicit <paramref name="serializer"/>.</typeparam>
+    /// <param name="msg">The message to publish. If <see cref="NatsMsg{T}.Data"/> implements <see cref="IDisposable"/> (e.g. <see cref="NatsMemoryOwner{T}"/> or any <see cref="System.Buffers.IMemoryOwner{T}"/>), ownership transfers to the publisher: the buffer is disposed after the bytes are written to the wire, or on any pre-publish throw.</param>
     /// <param name="opts">Optional per-message options.</param>
+    /// <param name="serializer">Optional serializer for the payload. When null, the connection's registered serializer is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     /// <remarks>
     /// When flow control is disabled (<see cref="NatsJSBatchFlowControl.AckFirst"/> is false and
     /// <see cref="NatsJSBatchFlowControl.AckEvery"/> is 0), this method publishes fire-and-forget.
     /// Server-side errors for individual messages are not observed until
-    /// <see cref="CommitAsync(string,byte[],NatsJSBatchMsgOpts,CancellationToken)"/> /
-    /// <see cref="CommitMsgAsync(NatsMsg{byte[]},NatsJSBatchMsgOpts,CancellationToken)"/> is called.
+    /// <see cref="CommitAsync{T}(string,T,NatsJSBatchMsgOpts,INatsSerialize{T},CancellationToken)"/> /
+    /// <see cref="CommitMsgAsync{T}(NatsMsg{T},NatsJSBatchMsgOpts,INatsSerialize{T},CancellationToken)"/> is called.
     /// </remarks>
-    Task AddMsgAsync(NatsMsg<byte[]> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Publishes a message to the batch using a pooled buffer payload.
-    /// </summary>
-    /// <param name="msg">The message to publish. Ownership of <see cref="NatsMsg{T}.Data"/> transfers to the publisher: the buffer is disposed after the bytes are written to the wire.</param>
-    /// <param name="opts">Optional per-message options.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
-    /// <remarks>
-    /// When flow control is disabled (<see cref="NatsJSBatchFlowControl.AckFirst"/> is false and
-    /// <see cref="NatsJSBatchFlowControl.AckEvery"/> is 0), this method publishes fire-and-forget.
-    /// Server-side errors for individual messages are not observed until
-    /// <see cref="CommitAsync(string,NatsMemoryOwner{byte},NatsJSBatchMsgOpts,CancellationToken)"/> /
-    /// <see cref="CommitMsgAsync(NatsMsg{NatsMemoryOwner{byte}},NatsJSBatchMsgOpts,CancellationToken)"/> is called.
-    /// </remarks>
-    Task AddMsgAsync(NatsMsg<NatsMemoryOwner<byte>> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default);
+    Task AddMsgAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Publishes the final message with the given subject and data, and commits the batch.
     /// </summary>
+    /// <typeparam name="T">The payload type. Resolved by the configured serializer or by an explicit <paramref name="serializer"/>.</typeparam>
     /// <param name="subject">The subject to publish the message to.</param>
-    /// <param name="data">The message data.</param>
+    /// <param name="data">The message data. If the value implements <see cref="IDisposable"/> (e.g. <see cref="NatsMemoryOwner{T}"/> or any <see cref="System.Buffers.IMemoryOwner{T}"/>), ownership transfers to the publisher: the buffer is disposed after the bytes are written to the wire, or on any pre-publish throw.</param>
     /// <param name="opts">Optional per-message options.</param>
+    /// <param name="serializer">Optional serializer for the payload. When null, the connection's registered serializer is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task containing the batch acknowledgment.</returns>
     /// <remarks>
@@ -108,30 +81,15 @@ public interface INatsJSBatchPublisher : IAsyncDisposable
     /// check the stream's last sequence to determine whether the batch was actually written before
     /// retrying.
     /// </remarks>
-    Task<NatsJSBatchAck> CommitAsync(string subject, byte[] data, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Publishes the final message with the given subject and data using a pooled buffer, and commits the batch.
-    /// </summary>
-    /// <param name="subject">The subject to publish the message to.</param>
-    /// <param name="data">The message data. Ownership transfers to the publisher: the buffer is disposed after the bytes are written to the wire.</param>
-    /// <param name="opts">Optional per-message options.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A task containing the batch acknowledgment.</returns>
-    /// <remarks>
-    /// If a <see cref="TimeoutException"/> or <see cref="OperationCanceledException"/> is thrown
-    /// after the commit request was sent, the batch may or may not have been persisted; the ack
-    /// may simply have been lost. There is no idempotency key for commits, so callers should
-    /// check the stream's last sequence to determine whether the batch was actually written before
-    /// retrying.
-    /// </remarks>
-    Task<NatsJSBatchAck> CommitAsync(string subject, NatsMemoryOwner<byte> data, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default);
+    Task<NatsJSBatchAck> CommitAsync<T>(string subject, T data, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Publishes the final message and commits the batch.
     /// </summary>
-    /// <param name="msg">The message to publish.</param>
+    /// <typeparam name="T">The payload type. Resolved by the configured serializer or by an explicit <paramref name="serializer"/>.</typeparam>
+    /// <param name="msg">The message to publish. If <see cref="NatsMsg{T}.Data"/> implements <see cref="IDisposable"/> (e.g. <see cref="NatsMemoryOwner{T}"/> or any <see cref="System.Buffers.IMemoryOwner{T}"/>), ownership transfers to the publisher: the buffer is disposed after the bytes are written to the wire, or on any pre-publish throw.</param>
     /// <param name="opts">Optional per-message options.</param>
+    /// <param name="serializer">Optional serializer for the payload. When null, the connection's registered serializer is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task containing the batch acknowledgment.</returns>
     /// <remarks>
@@ -141,23 +99,7 @@ public interface INatsJSBatchPublisher : IAsyncDisposable
     /// check the stream's last sequence to determine whether the batch was actually written before
     /// retrying.
     /// </remarks>
-    Task<NatsJSBatchAck> CommitMsgAsync(NatsMsg<byte[]> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Publishes the final message using a pooled buffer payload and commits the batch.
-    /// </summary>
-    /// <param name="msg">The message to publish. Ownership of <see cref="NatsMsg{T}.Data"/> transfers to the publisher: the buffer is disposed after the bytes are written to the wire.</param>
-    /// <param name="opts">Optional per-message options.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A task containing the batch acknowledgment.</returns>
-    /// <remarks>
-    /// If a <see cref="TimeoutException"/> or <see cref="OperationCanceledException"/> is thrown
-    /// after the commit request was sent, the batch may or may not have been persisted; the ack
-    /// may simply have been lost. There is no idempotency key for commits, so callers should
-    /// check the stream's last sequence to determine whether the batch was actually written before
-    /// retrying.
-    /// </remarks>
-    Task<NatsJSBatchAck> CommitMsgAsync(NatsMsg<NatsMemoryOwner<byte>> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default);
+    Task<NatsJSBatchAck> CommitMsgAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Cancels the batch without committing.

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublishExtensions.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublishExtensions.cs
@@ -14,15 +14,18 @@ public static class NatsJSBatchPublishExtensions
     /// <summary>
     /// Publishes a batch of messages to a Stream and waits for an ack for the commit.
     /// </summary>
+    /// <typeparam name="T">The payload type. Resolved by the configured serializer or by an explicit <paramref name="serializer"/>.</typeparam>
     /// <param name="js">The JetStream context to use for publishing.</param>
-    /// <param name="messages">The messages to publish as a batch.</param>
+    /// <param name="messages">The messages to publish as a batch. If a message's <see cref="NatsMsg{T}.Data"/> implements <see cref="IDisposable"/> (e.g. <see cref="NatsMemoryOwner{T}"/> or any <see cref="System.Buffers.IMemoryOwner{T}"/>), ownership transfers to the publisher: each buffer is disposed after its bytes are written to the wire, or on any pre-publish throw.</param>
     /// <param name="flowControl">Optional flow control configuration.</param>
+    /// <param name="serializer">Optional serializer for the payloads. When null, the connection's registered serializer is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>The batch acknowledgment from the server.</returns>
-    public static async Task<NatsJSBatchAck> PublishMsgBatchAsync(
+    public static async Task<NatsJSBatchAck> PublishMsgBatchAsync<T>(
         this INatsJSContext js,
-        IReadOnlyList<NatsMsg<byte[]>> messages,
+        IReadOnlyList<NatsMsg<T>> messages,
         NatsJSBatchFlowControl? flowControl = null,
+        INatsSerialize<T>? serializer = null,
         CancellationToken cancellationToken = default)
     {
         if (messages.Count == 0)
@@ -34,38 +37,9 @@ public static class NatsJSBatchPublishExtensions
 
         for (int i = 0; i < messages.Count - 1; i++)
         {
-            await publisher.AddMsgAsync(messages[i], cancellationToken: cancellationToken).ConfigureAwait(false);
+            await publisher.AddMsgAsync(messages[i], serializer: serializer, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        return await publisher.CommitMsgAsync(messages[messages.Count - 1], cancellationToken: cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Publishes a batch of messages backed by pooled buffers to a Stream and waits for an ack for the commit.
-    /// </summary>
-    /// <param name="js">The JetStream context to use for publishing.</param>
-    /// <param name="messages">The messages to publish as a batch. Ownership of each message's <see cref="NatsMsg{T}.Data"/> transfers to the publisher: each buffer is disposed after its bytes are written to the wire.</param>
-    /// <param name="flowControl">Optional flow control configuration.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>The batch acknowledgment from the server.</returns>
-    public static async Task<NatsJSBatchAck> PublishMsgBatchAsync(
-        this INatsJSContext js,
-        IReadOnlyList<NatsMsg<NatsMemoryOwner<byte>>> messages,
-        NatsJSBatchFlowControl? flowControl = null,
-        CancellationToken cancellationToken = default)
-    {
-        if (messages.Count == 0)
-        {
-            throw new ArgumentException("No messages to publish", nameof(messages));
-        }
-
-        await using var publisher = new NatsJSBatchPublisher(js, flowControl);
-
-        for (int i = 0; i < messages.Count - 1; i++)
-        {
-            await publisher.AddMsgAsync(messages[i], cancellationToken: cancellationToken).ConfigureAwait(false);
-        }
-
-        return await publisher.CommitMsgAsync(messages[messages.Count - 1], cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await publisher.CommitMsgAsync(messages[messages.Count - 1], serializer: serializer, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublishExtensions.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublishExtensions.cs
@@ -39,4 +39,33 @@ public static class NatsJSBatchPublishExtensions
 
         return await publisher.CommitMsgAsync(messages[messages.Count - 1], cancellationToken: cancellationToken).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Publishes a batch of messages backed by pooled buffers to a Stream and waits for an ack for the commit.
+    /// </summary>
+    /// <param name="js">The JetStream context to use for publishing.</param>
+    /// <param name="messages">The messages to publish as a batch. Ownership of each message's <see cref="NatsMsg{T}.Data"/> transfers to the publisher: each buffer is disposed after its bytes are written to the wire.</param>
+    /// <param name="flowControl">Optional flow control configuration.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The batch acknowledgment from the server.</returns>
+    public static async Task<NatsJSBatchAck> PublishMsgBatchAsync(
+        this INatsJSContext js,
+        IReadOnlyList<NatsMsg<NatsMemoryOwner<byte>>> messages,
+        NatsJSBatchFlowControl? flowControl = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (messages.Count == 0)
+        {
+            throw new ArgumentException("No messages to publish", nameof(messages));
+        }
+
+        await using var publisher = new NatsJSBatchPublisher(js, flowControl);
+
+        for (int i = 0; i < messages.Count - 1; i++)
+        {
+            await publisher.AddMsgAsync(messages[i], cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        return await publisher.CommitMsgAsync(messages[messages.Count - 1], cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
 }

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublishExtensions.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublishExtensions.cs
@@ -16,7 +16,7 @@ public static class NatsJSBatchPublishExtensions
     /// </summary>
     /// <typeparam name="T">The payload type. Resolved by the configured serializer or by an explicit <paramref name="serializer"/>.</typeparam>
     /// <param name="js">The JetStream context to use for publishing.</param>
-    /// <param name="messages">The messages to publish as a batch. If a message's <see cref="NatsMsg{T}.Data"/> implements <see cref="IDisposable"/> (e.g. <see cref="NatsMemoryOwner{T}"/> or any <see cref="System.Buffers.IMemoryOwner{T}"/>), ownership transfers to the publisher: each buffer is disposed after its bytes are written to the wire, or on any pre-publish throw.</param>
+    /// <param name="messages">The messages to publish as a batch. See remarks on <see cref="INatsJSBatchPublisher"/> for ownership semantics.</param>
     /// <param name="flowControl">Optional flow control configuration.</param>
     /// <param name="serializer">Optional serializer for the payloads. When null, the connection's registered serializer is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublisher.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublisher.cs
@@ -10,8 +10,8 @@ namespace Synadia.Orbit.JetStream.Publisher;
 /// Implementation of batch publisher for publishing messages to a stream in batches.
 /// </summary>
 /// <remarks>
-/// This class is not thread-safe. <see cref="AddAsync"/> and <see cref="AddMsgAsync"/> must be
-/// called sequentially by a single producer: concurrent calls can reach the socket in an order
+/// This class is not thread-safe. <c>AddAsync</c> and <c>AddMsgAsync</c> must be called
+/// sequentially by a single producer: concurrent calls can reach the socket in an order
 /// different from the one in which sequence numbers were assigned, and the server will reject
 /// out-of-order sequences.
 /// </remarks>
@@ -74,7 +74,90 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
     }
 
     /// <inheritdoc />
-    public async Task AddMsgAsync(NatsMsg<byte[]> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
+    public Task AddAsync(string subject, NatsMemoryOwner<byte> data, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
+    {
+        var msg = new NatsMsg<NatsMemoryOwner<byte>>
+        {
+            Subject = subject,
+            Data = data,
+        };
+        return AddMsgAsync(msg, opts, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task AddMsgAsync(NatsMsg<byte[]> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
+        => AddMsgInternalAsync(msg, opts, cancellationToken);
+
+    /// <inheritdoc />
+    public Task AddMsgAsync(NatsMsg<NatsMemoryOwner<byte>> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
+        => AddMsgInternalAsync(msg, opts, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<NatsJSBatchAck> CommitAsync(string subject, byte[] data, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
+    {
+        var msg = new NatsMsg<byte[]>
+        {
+            Subject = subject,
+            Data = data,
+        };
+        return CommitMsgAsync(msg, opts, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<NatsJSBatchAck> CommitAsync(string subject, NatsMemoryOwner<byte> data, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
+    {
+        var msg = new NatsMsg<NatsMemoryOwner<byte>>
+        {
+            Subject = subject,
+            Data = data,
+        };
+        return CommitMsgAsync(msg, opts, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<NatsJSBatchAck> CommitMsgAsync(NatsMsg<byte[]> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
+        => CommitMsgInternalAsync(msg, opts, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<NatsJSBatchAck> CommitMsgAsync(NatsMsg<NatsMemoryOwner<byte>> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
+        => CommitMsgInternalAsync(msg, opts, cancellationToken);
+
+    /// <inheritdoc />
+    public void Discard()
+    {
+        lock (_lock)
+        {
+            if (_closed)
+            {
+                throw new NatsJSBatchClosedException();
+            }
+
+            _closed = true;
+        }
+    }
+
+    /// <summary>
+    /// Closes the batch publisher locally. Equivalent to <see cref="Discard"/> when called on an
+    /// uncommitted batch: messages already sent with <c>AddAsync</c> or <c>AddMsgAsync</c>
+    /// remain as an incomplete batch on the server until the server's batch timeout expires and
+    /// the in-progress messages are garbage collected. To finalize a batch explicitly, call
+    /// <c>CommitAsync</c> or <c>CommitMsgAsync</c> before disposal.
+    /// </summary>
+    /// <returns>A completed <see cref="ValueTask"/>.</returns>
+    public ValueTask DisposeAsync()
+    {
+        lock (_lock)
+        {
+            if (!_closed)
+            {
+                _closed = true;
+            }
+        }
+
+        return default;
+    }
+
+    private async Task AddMsgInternalAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts, CancellationToken cancellationToken)
     {
         // Prepare headers on a fresh instance so we don't mutate the caller's NatsHeaders.
         // Validate opts before touching _sequence so a thrown ArgumentException doesn't leave a gap.
@@ -114,7 +197,7 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
         // If we don't need an ack, use core NATS publish
         if (!needsAck)
         {
-            await _js.Connection.PublishAsync(msgToSend.Subject, msgToSend.Data, headers: msgToSend.Headers, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await _js.Connection.PublishAsync<T>(msgToSend.Subject, msgToSend.Data!, headers: msgToSend.Headers, cancellationToken: cancellationToken).ConfigureAwait(false);
             return;
         }
 
@@ -127,7 +210,7 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
         NatsMsg<byte[]> response;
         try
         {
-            response = await _js.Connection.RequestAsync<byte[], byte[]>(
+            response = await _js.Connection.RequestAsync<T, byte[]>(
                 msgToSend.Subject,
                 msgToSend.Data,
                 headers: msgToSend.Headers,
@@ -167,19 +250,7 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
         }
     }
 
-    /// <inheritdoc />
-    public Task<NatsJSBatchAck> CommitAsync(string subject, byte[] data, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
-    {
-        var msg = new NatsMsg<byte[]>
-        {
-            Subject = subject,
-            Data = data,
-        };
-        return CommitMsgAsync(msg, opts, cancellationToken);
-    }
-
-    /// <inheritdoc />
-    public async Task<NatsJSBatchAck> CommitMsgAsync(NatsMsg<byte[]> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
+    private async Task<NatsJSBatchAck> CommitMsgInternalAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts, CancellationToken cancellationToken)
     {
         // Prepare headers on a fresh instance so we don't mutate the caller's NatsHeaders.
         // Validate opts before touching _sequence so a thrown ArgumentException doesn't close the batch.
@@ -217,7 +288,7 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
         NatsMsg<byte[]> response;
         try
         {
-            response = await _js.Connection.RequestAsync<byte[], byte[]>(
+            response = await _js.Connection.RequestAsync<T, byte[]>(
                 msgToSend.Subject,
                 msgToSend.Data,
                 headers: msgToSend.Headers,
@@ -252,41 +323,6 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
             BatchId = batchResponse.BatchId!,
             BatchSize = batchResponse.BatchSize,
         };
-    }
-
-    /// <inheritdoc />
-    public void Discard()
-    {
-        lock (_lock)
-        {
-            if (_closed)
-            {
-                throw new NatsJSBatchClosedException();
-            }
-
-            _closed = true;
-        }
-    }
-
-    /// <summary>
-    /// Closes the batch publisher locally. Equivalent to <see cref="Discard"/> when called on an
-    /// uncommitted batch: messages already sent with <see cref="AddAsync"/> or <see cref="AddMsgAsync"/>
-    /// remain as an incomplete batch on the server until the server's batch timeout expires and
-    /// the in-progress messages are garbage collected. To finalize a batch explicitly, call
-    /// <see cref="CommitAsync"/> or <see cref="CommitMsgAsync"/> before disposal.
-    /// </summary>
-    /// <returns>A completed <see cref="ValueTask"/>.</returns>
-    public ValueTask DisposeAsync()
-    {
-        lock (_lock)
-        {
-            if (!_closed)
-            {
-                _closed = true;
-            }
-        }
-
-        return default;
     }
 
     private void CloseOnError()

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublisher.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublisher.cs
@@ -129,15 +129,12 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
 
     private async Task AddMsgInternalAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts, INatsSerialize<T>? serializer, CancellationToken cancellationToken)
     {
-        // For pooled-buffer payloads (NatsMemoryOwner<byte> et al.) the serializer disposes
-        // the buffer inside PublishAsync/RequestAsync. Capture it here so we can dispose it on
-        // any throw before those calls (closed batch, invalid opts) and honour the
-        // ownership-transfer contract.
+        // Capture any IDisposable payload up front so we can dispose it on a pre-publish throw
+        // (closed batch, invalid opts). The serializer disposes it once the bytes are written.
         var owned = msg.Data as IDisposable;
         try
         {
-            // Prepare headers on a fresh instance so we don't mutate the caller's NatsHeaders.
-            // Validate opts before touching _sequence so a thrown ArgumentException doesn't leave a gap.
+            // Apply opts before taking _sequence so a thrown ArgumentException doesn't leave a gap.
             var headers = BatchPublishHelper.CloneHeaders(msg.Headers);
             BatchPublishHelper.ApplyBatchMessageOptions(headers, opts);
 
@@ -154,16 +151,8 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
                 _sequence++;
                 currentSeq = _sequence;
 
-                // Determine if we need flow control for this message
-                needsAck = false;
-                if (_flowControl.AckFirst && currentSeq == 1)
-                {
-                    needsAck = true; // wait on first message
-                }
-                else if (_flowControl.AckEvery > 0 && currentSeq % _flowControl.AckEvery == 0)
-                {
-                    needsAck = true; // periodic flow control
-                }
+                needsAck = (_flowControl.AckFirst && currentSeq == 1)
+                    || (_flowControl.AckEvery > 0 && currentSeq % _flowControl.AckEvery == 0);
             }
 
             headers[NatsJSBatchHeaders.BatchId] = _batchId;
@@ -171,15 +160,14 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
 
             var msgToSend = msg with { Headers = headers };
 
-            // If we don't need an ack, use core NATS publish
             if (!needsAck)
             {
-                owned = null; // ownership passes to PublishAsync's serializer
+                owned = null;
                 await _js.Connection.PublishAsync<T>(msgToSend.Subject, msgToSend.Data!, headers: msgToSend.Headers, serializer: serializer, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return;
             }
 
-            // Request with ack. Only allocate a linked CTS when the caller actually has a cancellable token.
+            // Only allocate a linked CTS when the caller actually has a cancellable token.
             using var cts = cancellationToken.CanBeCanceled
                 ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
                 : new CancellationTokenSource();
@@ -188,7 +176,7 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
             NatsMsg<byte[]> response;
             try
             {
-                owned = null; // ownership passes to RequestAsync's serializer
+                owned = null;
                 response = await _js.Connection.RequestAsync<T, byte[]>(
                     msgToSend.Subject,
                     msgToSend.Data,
@@ -198,13 +186,12 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
-                // Timed out waiting for the flow-control ack. The batch is effectively dead on
-                // the server; close locally so further Add/Commit calls fail fast.
+                // Batch is dead on the server after an ack timeout; close locally so further
+                // Add/Commit calls fail fast.
                 CloseOnError();
                 throw new TimeoutException($"Batch message {currentSeq} ack failed: timeout after {_ackTimeout}");
             }
 
-            // For flow control we expect no response data or an error
             if (response.Data?.Length > 0)
             {
                 BatchPublishApiResponse? apiResponse;
@@ -214,16 +201,16 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
                 }
                 catch (System.Text.Json.JsonException)
                 {
-                    // Malformed server response. The message was sent and the sequence advanced,
-                    // so the batch is now in an unrecoverable state.
+                    // Message was sent and the sequence advanced; a malformed response leaves
+                    // the batch unrecoverable.
                     CloseOnError();
                     throw;
                 }
 
                 if (apiResponse?.Error != null)
                 {
-                    // Server rejected the batch. Close locally so further Add/Commit calls fail fast
-                    // instead of silently targeting a dead batch.
+                    // Close locally so further Add/Commit calls fail fast instead of silently
+                    // targeting a server-rejected batch.
                     CloseOnError();
                     BatchPublishHelper.ThrowBatchPublishException(apiResponse.Error);
                 }
@@ -238,12 +225,10 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
 
     private async Task<NatsJSBatchAck> CommitMsgInternalAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts, INatsSerialize<T>? serializer, CancellationToken cancellationToken)
     {
-        // See AddMsgInternalAsync for why we capture the IDisposable up front.
         var owned = msg.Data as IDisposable;
         try
         {
-            // Prepare headers on a fresh instance so we don't mutate the caller's NatsHeaders.
-            // Validate opts before touching _sequence so a thrown ArgumentException doesn't close the batch.
+            // Apply opts before taking _sequence so a thrown ArgumentException doesn't close the batch.
             var headers = BatchPublishHelper.CloneHeaders(msg.Headers);
             BatchPublishHelper.ApplyBatchMessageOptions(headers, opts);
 
@@ -257,7 +242,7 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
                     throw new NatsJSBatchClosedException();
                 }
 
-                // Close the batch up-front so concurrent commits can't both send.
+                // Close up-front so concurrent commits can't both send.
                 _closed = true;
                 _sequence++;
                 currentSeq = _sequence;
@@ -270,15 +255,14 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
 
             var msgToSend = msg with { Headers = headers };
 
-            // Always bound the commit wait: even when the caller supplies a cancellation token,
-            // apply the ack timeout so a non-responsive server can't block indefinitely.
+            // Always bound the commit wait so a non-responsive server can't block indefinitely,
+            // even when the caller supplies a cancellation token.
             using var cts = BatchPublishHelper.CreateCommitCancellationTokenSource(cancellationToken, _ackTimeout);
 
-            // Request with ack
             NatsMsg<byte[]> response;
             try
             {
-                owned = null; // ownership passes to RequestAsync's serializer
+                owned = null;
                 response = await _js.Connection.RequestAsync<T, byte[]>(
                     msgToSend.Subject,
                     msgToSend.Data,

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublisher.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublisher.cs
@@ -63,64 +63,34 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
     }
 
     /// <inheritdoc />
-    public Task AddAsync(string subject, byte[] data, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
+    public Task AddAsync<T>(string subject, T data, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default)
     {
-        var msg = new NatsMsg<byte[]>
+        var msg = new NatsMsg<T>
         {
             Subject = subject,
             Data = data,
         };
-        return AddMsgAsync(msg, opts, cancellationToken);
+        return AddMsgInternalAsync(msg, opts, serializer, cancellationToken);
     }
 
     /// <inheritdoc />
-    public Task AddAsync(string subject, NatsMemoryOwner<byte> data, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
+    public Task AddMsgAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default)
+        => AddMsgInternalAsync(msg, opts, serializer, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<NatsJSBatchAck> CommitAsync<T>(string subject, T data, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default)
     {
-        var msg = new NatsMsg<NatsMemoryOwner<byte>>
+        var msg = new NatsMsg<T>
         {
             Subject = subject,
             Data = data,
         };
-        return AddMsgAsync(msg, opts, cancellationToken);
+        return CommitMsgInternalAsync(msg, opts, serializer, cancellationToken);
     }
 
     /// <inheritdoc />
-    public Task AddMsgAsync(NatsMsg<byte[]> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
-        => AddMsgInternalAsync(msg, opts, cancellationToken);
-
-    /// <inheritdoc />
-    public Task AddMsgAsync(NatsMsg<NatsMemoryOwner<byte>> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
-        => AddMsgInternalAsync(msg, opts, cancellationToken);
-
-    /// <inheritdoc />
-    public Task<NatsJSBatchAck> CommitAsync(string subject, byte[] data, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
-    {
-        var msg = new NatsMsg<byte[]>
-        {
-            Subject = subject,
-            Data = data,
-        };
-        return CommitMsgAsync(msg, opts, cancellationToken);
-    }
-
-    /// <inheritdoc />
-    public Task<NatsJSBatchAck> CommitAsync(string subject, NatsMemoryOwner<byte> data, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
-    {
-        var msg = new NatsMsg<NatsMemoryOwner<byte>>
-        {
-            Subject = subject,
-            Data = data,
-        };
-        return CommitMsgAsync(msg, opts, cancellationToken);
-    }
-
-    /// <inheritdoc />
-    public Task<NatsJSBatchAck> CommitMsgAsync(NatsMsg<byte[]> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
-        => CommitMsgInternalAsync(msg, opts, cancellationToken);
-
-    /// <inheritdoc />
-    public Task<NatsJSBatchAck> CommitMsgAsync(NatsMsg<NatsMemoryOwner<byte>> msg, NatsJSBatchMsgOpts? opts = null, CancellationToken cancellationToken = default)
-        => CommitMsgInternalAsync(msg, opts, cancellationToken);
+    public Task<NatsJSBatchAck> CommitMsgAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default)
+        => CommitMsgInternalAsync(msg, opts, serializer, cancellationToken);
 
     /// <inheritdoc />
     public void Discard()
@@ -157,9 +127,9 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
         return default;
     }
 
-    private async Task AddMsgInternalAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts, CancellationToken cancellationToken)
+    private async Task AddMsgInternalAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts, INatsSerialize<T>? serializer, CancellationToken cancellationToken)
     {
-        // For pooled-buffer payloads (NatsMemoryOwner<byte> et al.) NatsRawSerializer disposes
+        // For pooled-buffer payloads (NatsMemoryOwner<byte> et al.) the serializer disposes
         // the buffer inside PublishAsync/RequestAsync. Capture it here so we can dispose it on
         // any throw before those calls (closed batch, invalid opts) and honour the
         // ownership-transfer contract.
@@ -205,7 +175,7 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
             if (!needsAck)
             {
                 owned = null; // ownership passes to PublishAsync's serializer
-                await _js.Connection.PublishAsync<T>(msgToSend.Subject, msgToSend.Data!, headers: msgToSend.Headers, cancellationToken: cancellationToken).ConfigureAwait(false);
+                await _js.Connection.PublishAsync<T>(msgToSend.Subject, msgToSend.Data!, headers: msgToSend.Headers, serializer: serializer, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return;
             }
 
@@ -223,6 +193,7 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
                     msgToSend.Subject,
                     msgToSend.Data,
                     headers: msgToSend.Headers,
+                    requestSerializer: serializer,
                     cancellationToken: cts.Token).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
@@ -265,7 +236,7 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
         }
     }
 
-    private async Task<NatsJSBatchAck> CommitMsgInternalAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts, CancellationToken cancellationToken)
+    private async Task<NatsJSBatchAck> CommitMsgInternalAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts, INatsSerialize<T>? serializer, CancellationToken cancellationToken)
     {
         // See AddMsgInternalAsync for why we capture the IDisposable up front.
         var owned = msg.Data as IDisposable;
@@ -312,6 +283,7 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
                     msgToSend.Subject,
                     msgToSend.Data,
                     headers: msgToSend.Headers,
+                    requestSerializer: serializer,
                     cancellationToken: cts.Token).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublisher.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublisher.cs
@@ -159,170 +159,196 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
 
     private async Task AddMsgInternalAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts, CancellationToken cancellationToken)
     {
-        // Prepare headers on a fresh instance so we don't mutate the caller's NatsHeaders.
-        // Validate opts before touching _sequence so a thrown ArgumentException doesn't leave a gap.
-        var headers = BatchPublishHelper.CloneHeaders(msg.Headers);
-        BatchPublishHelper.ApplyBatchMessageOptions(headers, opts);
-
-        int currentSeq;
-        bool needsAck;
-
-        lock (_lock)
-        {
-            if (_closed)
-            {
-                throw new NatsJSBatchClosedException();
-            }
-
-            _sequence++;
-            currentSeq = _sequence;
-
-            // Determine if we need flow control for this message
-            needsAck = false;
-            if (_flowControl.AckFirst && currentSeq == 1)
-            {
-                needsAck = true; // wait on first message
-            }
-            else if (_flowControl.AckEvery > 0 && currentSeq % _flowControl.AckEvery == 0)
-            {
-                needsAck = true; // periodic flow control
-            }
-        }
-
-        headers[NatsJSBatchHeaders.BatchId] = _batchId;
-        headers[NatsJSBatchHeaders.BatchSeq] = currentSeq.ToString();
-
-        var msgToSend = msg with { Headers = headers };
-
-        // If we don't need an ack, use core NATS publish
-        if (!needsAck)
-        {
-            await _js.Connection.PublishAsync<T>(msgToSend.Subject, msgToSend.Data!, headers: msgToSend.Headers, cancellationToken: cancellationToken).ConfigureAwait(false);
-            return;
-        }
-
-        // Request with ack. Only allocate a linked CTS when the caller actually has a cancellable token.
-        using var cts = cancellationToken.CanBeCanceled
-            ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
-            : new CancellationTokenSource();
-        cts.CancelAfter(_ackTimeout);
-
-        NatsMsg<byte[]> response;
+        // For pooled-buffer payloads (NatsMemoryOwner<byte> et al.) NatsRawSerializer disposes
+        // the buffer inside PublishAsync/RequestAsync. Capture it here so we can dispose it on
+        // any throw before those calls (closed batch, invalid opts) and honour the
+        // ownership-transfer contract.
+        var owned = msg.Data as IDisposable;
         try
         {
-            response = await _js.Connection.RequestAsync<T, byte[]>(
-                msgToSend.Subject,
-                msgToSend.Data,
-                headers: msgToSend.Headers,
-                cancellationToken: cts.Token).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-        {
-            // Timed out waiting for the flow-control ack. The batch is effectively dead on
-            // the server; close locally so further Add/Commit calls fail fast.
-            CloseOnError();
-            throw new TimeoutException($"Batch message {currentSeq} ack failed: timeout after {_ackTimeout}");
-        }
+            // Prepare headers on a fresh instance so we don't mutate the caller's NatsHeaders.
+            // Validate opts before touching _sequence so a thrown ArgumentException doesn't leave a gap.
+            var headers = BatchPublishHelper.CloneHeaders(msg.Headers);
+            BatchPublishHelper.ApplyBatchMessageOptions(headers, opts);
 
-        // For flow control we expect no response data or an error
-        if (response.Data?.Length > 0)
-        {
-            BatchPublishApiResponse? apiResponse;
+            int currentSeq;
+            bool needsAck;
+
+            lock (_lock)
+            {
+                if (_closed)
+                {
+                    throw new NatsJSBatchClosedException();
+                }
+
+                _sequence++;
+                currentSeq = _sequence;
+
+                // Determine if we need flow control for this message
+                needsAck = false;
+                if (_flowControl.AckFirst && currentSeq == 1)
+                {
+                    needsAck = true; // wait on first message
+                }
+                else if (_flowControl.AckEvery > 0 && currentSeq % _flowControl.AckEvery == 0)
+                {
+                    needsAck = true; // periodic flow control
+                }
+            }
+
+            headers[NatsJSBatchHeaders.BatchId] = _batchId;
+            headers[NatsJSBatchHeaders.BatchSeq] = currentSeq.ToString();
+
+            var msgToSend = msg with { Headers = headers };
+
+            // If we don't need an ack, use core NATS publish
+            if (!needsAck)
+            {
+                owned = null; // ownership passes to PublishAsync's serializer
+                await _js.Connection.PublishAsync<T>(msgToSend.Subject, msgToSend.Data!, headers: msgToSend.Headers, cancellationToken: cancellationToken).ConfigureAwait(false);
+                return;
+            }
+
+            // Request with ack. Only allocate a linked CTS when the caller actually has a cancellable token.
+            using var cts = cancellationToken.CanBeCanceled
+                ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+                : new CancellationTokenSource();
+            cts.CancelAfter(_ackTimeout);
+
+            NatsMsg<byte[]> response;
             try
             {
-                apiResponse = BatchPublishHelper.DeserializeApiResponse(response.Data);
+                owned = null; // ownership passes to RequestAsync's serializer
+                response = await _js.Connection.RequestAsync<T, byte[]>(
+                    msgToSend.Subject,
+                    msgToSend.Data,
+                    headers: msgToSend.Headers,
+                    cancellationToken: cts.Token).ConfigureAwait(false);
             }
-            catch (System.Text.Json.JsonException)
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
-                // Malformed server response. The message was sent and the sequence advanced,
-                // so the batch is now in an unrecoverable state.
+                // Timed out waiting for the flow-control ack. The batch is effectively dead on
+                // the server; close locally so further Add/Commit calls fail fast.
                 CloseOnError();
-                throw;
+                throw new TimeoutException($"Batch message {currentSeq} ack failed: timeout after {_ackTimeout}");
             }
 
-            if (apiResponse?.Error != null)
+            // For flow control we expect no response data or an error
+            if (response.Data?.Length > 0)
             {
-                // Server rejected the batch. Close locally so further Add/Commit calls fail fast
-                // instead of silently targeting a dead batch.
-                CloseOnError();
-                BatchPublishHelper.ThrowBatchPublishException(apiResponse.Error);
+                BatchPublishApiResponse? apiResponse;
+                try
+                {
+                    apiResponse = BatchPublishHelper.DeserializeApiResponse(response.Data);
+                }
+                catch (System.Text.Json.JsonException)
+                {
+                    // Malformed server response. The message was sent and the sequence advanced,
+                    // so the batch is now in an unrecoverable state.
+                    CloseOnError();
+                    throw;
+                }
+
+                if (apiResponse?.Error != null)
+                {
+                    // Server rejected the batch. Close locally so further Add/Commit calls fail fast
+                    // instead of silently targeting a dead batch.
+                    CloseOnError();
+                    BatchPublishHelper.ThrowBatchPublishException(apiResponse.Error);
+                }
             }
+        }
+        catch
+        {
+            owned?.Dispose();
+            throw;
         }
     }
 
     private async Task<NatsJSBatchAck> CommitMsgInternalAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts, CancellationToken cancellationToken)
     {
-        // Prepare headers on a fresh instance so we don't mutate the caller's NatsHeaders.
-        // Validate opts before touching _sequence so a thrown ArgumentException doesn't close the batch.
-        var headers = BatchPublishHelper.CloneHeaders(msg.Headers);
-        BatchPublishHelper.ApplyBatchMessageOptions(headers, opts);
-
-        int currentSeq;
-        string batchId;
-
-        lock (_lock)
-        {
-            if (_closed)
-            {
-                throw new NatsJSBatchClosedException();
-            }
-
-            // Close the batch up-front so concurrent commits can't both send.
-            _closed = true;
-            _sequence++;
-            currentSeq = _sequence;
-            batchId = _batchId;
-        }
-
-        headers[NatsJSBatchHeaders.BatchId] = batchId;
-        headers[NatsJSBatchHeaders.BatchSeq] = currentSeq.ToString();
-        headers[NatsJSBatchHeaders.BatchCommit] = "1";
-
-        var msgToSend = msg with { Headers = headers };
-
-        // Always bound the commit wait: even when the caller supplies a cancellation token,
-        // apply the ack timeout so a non-responsive server can't block indefinitely.
-        using var cts = BatchPublishHelper.CreateCommitCancellationTokenSource(cancellationToken, _ackTimeout);
-
-        // Request with ack
-        NatsMsg<byte[]> response;
+        // See AddMsgInternalAsync for why we capture the IDisposable up front.
+        var owned = msg.Data as IDisposable;
         try
         {
-            response = await _js.Connection.RequestAsync<T, byte[]>(
-                msgToSend.Subject,
-                msgToSend.Data,
-                headers: msgToSend.Headers,
-                cancellationToken: cts.Token).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-        {
-            throw new TimeoutException($"Batch commit ack failed: timeout after {_ackTimeout}");
-        }
+            // Prepare headers on a fresh instance so we don't mutate the caller's NatsHeaders.
+            // Validate opts before touching _sequence so a thrown ArgumentException doesn't close the batch.
+            var headers = BatchPublishHelper.CloneHeaders(msg.Headers);
+            BatchPublishHelper.ApplyBatchMessageOptions(headers, opts);
 
-        var batchResponse = BatchPublishHelper.DeserializeAckResponse(response.Data);
+            int currentSeq;
+            string batchId;
 
-        if (batchResponse?.Error != null)
-        {
-            BatchPublishHelper.ThrowBatchPublishException(batchResponse.Error);
+            lock (_lock)
+            {
+                if (_closed)
+                {
+                    throw new NatsJSBatchClosedException();
+                }
+
+                // Close the batch up-front so concurrent commits can't both send.
+                _closed = true;
+                _sequence++;
+                currentSeq = _sequence;
+                batchId = _batchId;
+            }
+
+            headers[NatsJSBatchHeaders.BatchId] = batchId;
+            headers[NatsJSBatchHeaders.BatchSeq] = currentSeq.ToString();
+            headers[NatsJSBatchHeaders.BatchCommit] = "1";
+
+            var msgToSend = msg with { Headers = headers };
+
+            // Always bound the commit wait: even when the caller supplies a cancellation token,
+            // apply the ack timeout so a non-responsive server can't block indefinitely.
+            using var cts = BatchPublishHelper.CreateCommitCancellationTokenSource(cancellationToken, _ackTimeout);
+
+            // Request with ack
+            NatsMsg<byte[]> response;
+            try
+            {
+                owned = null; // ownership passes to RequestAsync's serializer
+                response = await _js.Connection.RequestAsync<T, byte[]>(
+                    msgToSend.Subject,
+                    msgToSend.Data,
+                    headers: msgToSend.Headers,
+                    cancellationToken: cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException($"Batch commit ack failed: timeout after {_ackTimeout}");
+            }
+
+            var batchResponse = BatchPublishHelper.DeserializeAckResponse(response.Data);
+
+            if (batchResponse?.Error != null)
+            {
+                BatchPublishHelper.ThrowBatchPublishException(batchResponse.Error);
+            }
+
+            if (batchResponse == null ||
+                string.IsNullOrEmpty(batchResponse.Stream) ||
+                batchResponse.BatchId != batchId ||
+                batchResponse.BatchSize != currentSeq)
+            {
+                throw new NatsJSInvalidBatchAckException();
+            }
+
+            return new NatsJSBatchAck
+            {
+                Stream = batchResponse.Stream!,
+                Sequence = batchResponse.Seq,
+                Domain = batchResponse.Domain,
+                Value = batchResponse.Value,
+                BatchId = batchResponse.BatchId!,
+                BatchSize = batchResponse.BatchSize,
+            };
         }
-
-        if (batchResponse == null ||
-            string.IsNullOrEmpty(batchResponse.Stream) ||
-            batchResponse.BatchId != batchId ||
-            batchResponse.BatchSize != currentSeq)
+        catch
         {
-            throw new NatsJSInvalidBatchAckException();
+            owned?.Dispose();
+            throw;
         }
-
-        return new NatsJSBatchAck
-        {
-            Stream = batchResponse.Stream!,
-            Sequence = batchResponse.Seq,
-            Domain = batchResponse.Domain,
-            Value = batchResponse.Value,
-            BatchId = batchResponse.BatchId!,
-            BatchSize = batchResponse.BatchSize,
-        };
     }
 
     private void CloseOnError()

--- a/tests/Synadia.Orbit.JetStream.Publisher.Test/JetStreamBatchPublishMemoryOwnerTest.cs
+++ b/tests/Synadia.Orbit.JetStream.Publisher.Test/JetStreamBatchPublishMemoryOwnerTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Synadia Communications, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using System.Buffers;
 using NATS.Client.Core;
 using NATS.Client.JetStream;
 using NATS.Client.JetStream.Models;
@@ -158,6 +159,34 @@ public class JetStreamBatchPublishMemoryOwnerTest
         Assert.Equal(2L, stream.Info.State.Messages);
     }
 
+    [Fact]
+    public async Task Memory_owner_disposed_when_batch_already_closed()
+    {
+        // Regression: pooled buffers transferred to the publisher must be disposed even when
+        // the call throws before reaching the wire (closed batch, invalid opts).
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectAsync();
+        Assert.SkipUnless(connection.HasMinServerVersion(2, 12), $"Server version {connection.ServerInfo?.Version} does not support batch publish (requires 2.12+)");
+
+        var js = connection.CreateJetStreamContext();
+        var ct = TestContext.Current.CancellationToken;
+
+        await using var batch = new NatsJSBatchPublisher(js);
+        batch.Discard();
+
+        var pool = new TrackingArrayPool<byte>();
+
+        var addOwner = NatsMemoryOwner<byte>.Allocate(8, pool);
+        await Assert.ThrowsAsync<NatsJSBatchClosedException>(
+            async () => await batch.AddAsync("subj", addOwner, cancellationToken: ct));
+
+        var commitOwner = NatsMemoryOwner<byte>.Allocate(8, pool);
+        await Assert.ThrowsAsync<NatsJSBatchClosedException>(
+            async () => await batch.CommitAsync("subj", commitOwner, cancellationToken: ct));
+
+        Assert.Equal(2, pool.ReturnCount);
+    }
+
     private static NatsMemoryOwner<byte> AllocateOwner(ReadOnlySpan<byte> data)
     {
         var owner = NatsMemoryOwner<byte>.Allocate(data.Length);
@@ -167,4 +196,20 @@ public class JetStreamBatchPublishMemoryOwnerTest
 
     private static NatsMemoryOwner<byte> AllocateOwner(string text)
         => AllocateOwner(System.Text.Encoding.UTF8.GetBytes(text));
+
+    private sealed class TrackingArrayPool<T> : ArrayPool<T>
+    {
+        private readonly ArrayPool<T> _inner = ArrayPool<T>.Shared;
+        private int _returnCount;
+
+        public int ReturnCount => Volatile.Read(ref _returnCount);
+
+        public override T[] Rent(int minimumLength) => _inner.Rent(minimumLength);
+
+        public override void Return(T[] array, bool clearArray = false)
+        {
+            Interlocked.Increment(ref _returnCount);
+            _inner.Return(array, clearArray);
+        }
+    }
 }

--- a/tests/Synadia.Orbit.JetStream.Publisher.Test/JetStreamBatchPublishMemoryOwnerTest.cs
+++ b/tests/Synadia.Orbit.JetStream.Publisher.Test/JetStreamBatchPublishMemoryOwnerTest.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using NATS.Client.Core;
+using NATS.Client.JetStream;
+using NATS.Client.JetStream.Models;
+using NATS.Net;
+using Synadia.Orbit.TestUtils;
+
+namespace Synadia.Orbit.JetStream.Publisher.Test;
+
+[Collection("nats-server")]
+public class JetStreamBatchPublishMemoryOwnerTest
+{
+    private readonly NatsServerFixture _server;
+
+    public JetStreamBatchPublishMemoryOwnerTest(NatsServerFixture server)
+    {
+        _server = server;
+    }
+
+    [Fact]
+    public async Task Memory_owner_basic_batch_publishing()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectAsync();
+        Assert.SkipUnless(connection.HasMinServerVersion(2, 12), $"Server version {connection.ServerInfo?.Version} does not support batch publish (requires 2.12+)");
+
+        var js = connection.CreateJetStreamContext();
+        var prefix = _server.GetNextId();
+        var streamName = $"{prefix}TEST";
+        var subject = $"{prefix}test";
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var stream = await js.CreateStreamAsync(
+            new StreamConfig(streamName, [$"{subject}.>"]) { AllowAtomicPublish = true },
+            ct);
+
+        await using var batch = new NatsJSBatchPublisher(js);
+
+        await batch.AddAsync($"{subject}.1", AllocateOwner("message 1"u8), cancellationToken: ct);
+        await batch.AddMsgAsync(
+            new NatsMsg<NatsMemoryOwner<byte>>
+            {
+                Subject = $"{subject}.2",
+                Data = AllocateOwner("message 2"u8),
+            },
+            cancellationToken: ct);
+
+        Assert.Equal(2, batch.Size);
+
+        await stream.RefreshAsync(ct);
+        Assert.Equal(0L, stream.Info.State.Messages);
+
+        var ack = await batch.CommitAsync($"{subject}.3", AllocateOwner("message 3"u8), cancellationToken: ct);
+
+        Assert.NotNull(ack);
+        Assert.Equal(3, ack.BatchSize);
+        Assert.Equal(streamName, ack.Stream);
+
+        Assert.True(batch.IsClosed);
+
+        await stream.RefreshAsync(ct);
+        Assert.Equal(3L, stream.Info.State.Messages);
+
+        // Read messages back and verify payloads were written correctly through the pooled-buffer path.
+        var consumer = await stream.CreateOrUpdateConsumerAsync(
+            new ConsumerConfig($"{prefix}consumer") { AckPolicy = ConsumerConfigAckPolicy.None },
+            ct);
+        var seen = new List<string>();
+        await foreach (var m in consumer.FetchAsync<string>(new NatsJSFetchOpts { MaxMsgs = 3 }, cancellationToken: ct))
+        {
+            seen.Add(m.Data!);
+        }
+
+        Assert.Equal(new[] { "message 1", "message 2", "message 3" }, seen);
+    }
+
+    [Fact]
+    public async Task Memory_owner_commit_msg_and_publish_msg_batch()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectAsync();
+        Assert.SkipUnless(connection.HasMinServerVersion(2, 12), $"Server version {connection.ServerInfo?.Version} does not support batch publish (requires 2.12+)");
+
+        var js = connection.CreateJetStreamContext();
+        var prefix = _server.GetNextId();
+        var streamName = $"{prefix}TEST";
+        var subject = $"{prefix}test";
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var stream = await js.CreateStreamAsync(
+            new StreamConfig(streamName, [$"{subject}.>"]) { AllowAtomicPublish = true },
+            ct);
+
+        const int count = 10;
+        var messages = new NatsMsg<NatsMemoryOwner<byte>>[count];
+        for (int i = 0; i < count; i++)
+        {
+            messages[i] = new NatsMsg<NatsMemoryOwner<byte>>
+            {
+                Subject = $"{subject}.subject",
+                Data = AllocateOwner($"message {i}"),
+            };
+        }
+
+        var ack = await js.PublishMsgBatchAsync(messages, cancellationToken: ct);
+
+        Assert.NotNull(ack);
+        Assert.Equal(count, ack.BatchSize);
+
+        await stream.RefreshAsync(ct);
+        Assert.Equal(count, stream.Info.State.Messages);
+    }
+
+    [Fact]
+    public async Task Memory_owner_with_flow_control_ack()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectAsync();
+        Assert.SkipUnless(connection.HasMinServerVersion(2, 12), $"Server version {connection.ServerInfo?.Version} does not support batch publish (requires 2.12+)");
+
+        var js = connection.CreateJetStreamContext();
+        var prefix = _server.GetNextId();
+        var streamName = $"{prefix}TEST";
+        var subject = $"{prefix}test";
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var stream = await js.CreateStreamAsync(
+            new StreamConfig(streamName, [$"{subject}.>"]) { AllowAtomicPublish = true },
+            ct);
+
+        // AckFirst exercises the RequestAsync flow-control path (not just fire-and-forget publish)
+        // for an IMemoryOwner payload.
+        await using var batch = new NatsJSBatchPublisher(
+            js,
+            new NatsJSBatchFlowControl
+            {
+                AckFirst = true,
+                AckTimeout = TimeSpan.FromSeconds(5),
+            });
+
+        await batch.AddAsync($"{subject}.1", AllocateOwner("hello"u8), cancellationToken: ct);
+        var ack = await batch.CommitMsgAsync(
+            new NatsMsg<NatsMemoryOwner<byte>>
+            {
+                Subject = $"{subject}.2",
+                Data = AllocateOwner("world"u8),
+            },
+            cancellationToken: ct);
+
+        Assert.Equal(2, ack.BatchSize);
+
+        await stream.RefreshAsync(ct);
+        Assert.Equal(2L, stream.Info.State.Messages);
+    }
+
+    private static NatsMemoryOwner<byte> AllocateOwner(ReadOnlySpan<byte> data)
+    {
+        var owner = NatsMemoryOwner<byte>.Allocate(data.Length);
+        data.CopyTo(owner.Memory.Span);
+        return owner;
+    }
+
+    private static NatsMemoryOwner<byte> AllocateOwner(string text)
+        => AllocateOwner(System.Text.Encoding.UTF8.GetBytes(text));
+}

--- a/tests/Synadia.Orbit.JetStream.Publisher.Test/JetStreamBatchPublishTest.cs
+++ b/tests/Synadia.Orbit.JetStream.Publisher.Test/JetStreamBatchPublishTest.cs
@@ -120,7 +120,7 @@ public class JetStreamBatchPublishTest
             $"{subject}.1",
             "message 1"u8.ToArray(),
             new NatsJSBatchMsgOpts { LastSeq = 5, Stream = streamName },
-            ct);
+            cancellationToken: ct);
 
         // Add second message with expected stream
         await batch.AddMsgAsync(
@@ -130,7 +130,7 @@ public class JetStreamBatchPublishTest
                 Data = "message 2"u8.ToArray(),
             },
             new NatsJSBatchMsgOpts { Stream = streamName },
-            ct);
+            cancellationToken: ct);
 
         // Commit third message
         var ack = await batch.CommitAsync($"{subject}.3", "message 3"u8.ToArray(), cancellationToken: ct);
@@ -168,7 +168,7 @@ public class JetStreamBatchPublishTest
             $"{subject}.1",
             "message 1"u8.ToArray(),
             new NatsJSBatchMsgOpts { LastSeq = 0 },
-            ct);
+            cancellationToken: ct);
 
         var ack = await batch.CommitAsync($"{subject}.2", "message 2"u8.ToArray(), cancellationToken: ct);
 
@@ -202,7 +202,7 @@ public class JetStreamBatchPublishTest
                 $"{subject}.1",
                 "message 1"u8.ToArray(),
                 new NatsJSBatchMsgOpts { LastSeq = 5 },
-                ct));
+                cancellationToken: ct));
 
         _output.WriteLine($"Exception: {ex.Message}");
     }


### PR DESCRIPTION
Adds `NatsMemoryOwner<byte>` overloads on `NatsJSBatchPublisher` (Add/AddMsg/Commit/CommitMsg) and `PublishMsgBatchAsync`, so callers using pooled buffers can avoid copying into a `byte[]` before publishing. Ownership transfers to the publisher: the buffer is disposed after the bytes are written to the wire, matching the native `PublishAsync<NatsMemoryOwner<byte>>` behavior.

Fixes #54