### PR TITLE
Rewrite README intro as TLDR list

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@
   <img src="orbit-small.png">
 </p>
 
-Orbit .NET is a set of independent NuGet packages that build on NATS .NET.
-Each package solves one problem the core client doesn't:
+Orbit .NET is a set of independent NuGet packages that build on [NATS .NET](https://github.com/nats-io/nats.net).
+Each one solves a problem the core client doesn't cover:
 
-- JetStream: backpressure publisher, batch retrieval, scheduled messages
-- Consumers: partitioned consumer groups (static and elastic)
-- Core: request-many with sentinel, distributed counters
-- KV: key encoding codecs
-- Tooling: CLI context loader, plugin framework, parameterized subjects
-- Testing: NATS server process manager
+- **Scaling consumers across instances?** -> Partitioned consumer groups with auto-balancing and self-healing
+- **Publishing at high throughput?** -> Pipelined ack publisher + atomic batch commits
+- **Need delayed or scheduled delivery?** -> Schedule messages for future publish on JetStream
+- **Distributed counters without a separate store?** -> Atomic inc/dec backed by JetStream streams
+- **KV keys with special characters?** -> Base64 and path-style key codecs
+- **Sharing NATS CLI context with your app?** -> Read `~/.config/nats/context/` files into `NatsOpts`
+- **Integration testing?** -> Spin up `nats-server` with auto port assignment and JetStream
 
 Use what you need. APIs may change until a package reaches v1.0.0.
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,17 @@
   <img src="orbit-small.png">
 </p>
 
-Orbit .NET is a set of independent utilities around NATS ecosystem that aims to
-boost productivity and provide higher abstraction layer for NATS .NET
-clients. Note that these libraries will evolve rapidly and API guarantees are
-not made until the specific project has a v1.0.0 version.
+Orbit .NET is a set of independent NuGet packages that build on NATS .NET.
+Each package solves one problem the core client doesn't:
+
+- JetStream: backpressure publisher, batch retrieval, scheduled messages
+- Consumers: partitioned consumer groups (static and elastic)
+- Core: request-many with sentinel, distributed counters
+- KV: key encoding codecs
+- Tooling: CLI context loader, plugin framework, parameterized subjects
+- Testing: NATS server process manager
+
+Use what you need. APIs may change until a package reaches v1.0.0.
 
 # Packages
 


### PR DESCRIPTION
Replace the vague "set of independent utilities... boost productivity" intro with a short bulleted TLDR grouping the packages by area, so a first-time visitor can tell what's in the repo without scanning the table. Keeps the v1.0.0 stability caveat.