### PR TITLE
Release JetStream.Publisher 1.0.0-preview.5

### DIFF
--- a/src/Synadia.Orbit.JetStream.Publisher/version.txt
+++ b/src/Synadia.Orbit.JetStream.Publisher/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.4
+1.0.0-preview.5


### PR DESCRIPTION
Adds `NatsMemoryOwner<byte>` payload support to the batch publisher, allowing zero-copy scenarios where ownership of pooled memory transfers to the publisher. Thanks to @colprog for the feature request (#54).

- Make batch publisher payload generic (#55)