### PR TITLE
Add cron schedule support

### DIFF
--- a/src/Synadia.Orbit.JetStream.Extensions/JetStreamExtensions.cs
+++ b/src/Synadia.Orbit.JetStream.Extensions/JetStreamExtensions.cs
@@ -69,7 +69,8 @@ public static class JetStreamExtensions
     /// <c>AllowMsgTTL</c> enabled. The target subject specified in the schedule must be within the
     /// stream's subject filter.
     /// <para>Server version requirements: <c>@at</c> schedules require NATS Server 2.12+.
-    /// <c>@every</c> (repeating interval) and <c>Source</c> (data sampling) require NATS Server 2.14+.</para>
+    /// <c>@every</c> (repeating interval), cron schedules, predefined schedules
+    /// (<c>@hourly</c>, <c>@daily</c>, ...), and <c>Source</c> (data sampling) require NATS Server 2.14+.</para>
     /// </remarks>
     public static ValueTask<PubAckResponse> PublishScheduledAsync(
         this INatsJSContext context,
@@ -101,7 +102,8 @@ public static class JetStreamExtensions
     /// <c>AllowMsgTTL</c> enabled. The target subject specified in the schedule must be within the
     /// stream's subject filter.
     /// <para>Server version requirements: <c>@at</c> schedules require NATS Server 2.12+.
-    /// <c>@every</c> (repeating interval) and <c>Source</c> (data sampling) require NATS Server 2.14+.</para>
+    /// <c>@every</c> (repeating interval), cron schedules, predefined schedules
+    /// (<c>@hourly</c>, <c>@daily</c>, ...), and <c>Source</c> (data sampling) require NATS Server 2.14+.</para>
     /// </remarks>
     public static ValueTask<PubAckResponse> PublishScheduledAsync<T>(
         this INatsJSContext context,

--- a/src/Synadia.Orbit.JetStream.Extensions/Models/NatsMsgSchedule.cs
+++ b/src/Synadia.Orbit.JetStream.Extensions/Models/NatsMsgSchedule.cs
@@ -174,7 +174,21 @@ public record NatsMsgSchedule
     /// Example: <c>"0 0 * * * *"</c> for the start of every hour.</param>
     /// <param name="target">The target subject for message delivery.</param>
     /// <returns>A new <see cref="NatsMsgSchedule"/> configured with the given cron expression.</returns>
-    public static NatsMsgSchedule Cron(string cron, string target) => new(cron, target);
+    /// <exception cref="ArgumentException">Thrown when <paramref name="cron"/> starts with <c>@at </c> or <c>@every </c>.
+    /// Use the <see cref="DateTimeOffset"/> or <see cref="TimeSpan"/> constructors for those schedule types.</exception>
+    public static NatsMsgSchedule Cron(string cron, string target)
+    {
+        if (cron is not null &&
+            (cron.StartsWith("@at ", StringComparison.Ordinal) ||
+             cron.StartsWith("@every ", StringComparison.Ordinal)))
+        {
+            throw new ArgumentException(
+                "Cron(...) does not accept @at or @every expressions; use the DateTimeOffset or TimeSpan constructors instead.",
+                nameof(cron));
+        }
+
+        return new(cron!, target);
+    }
 
     /// <summary>Creates a schedule that fires once a year at midnight on January 1st (UTC by default). Requires NATS Server 2.14 or later.</summary>
     /// <param name="target">The target subject for message delivery.</param>
@@ -207,6 +221,7 @@ public record NatsMsgSchedule
     /// <param name="existingHeaders">Optional existing headers to merge with. If null, new headers are created.</param>
     /// <returns>A <see cref="NatsHeaders"/> instance containing the scheduling headers.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <see cref="Ttl"/> is less than 1 second and not <see cref="TimeSpan.MaxValue"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <see cref="TimeZone"/> is set to an empty or whitespace string.</exception>
     /// <exception cref="InvalidOperationException">Thrown when <see cref="TimeZone"/> is set on a non-cron schedule (<c>@at</c> or <c>@every</c>).</exception>
     public NatsHeaders ToHeaders(NatsHeaders? existingHeaders = null)
     {
@@ -222,6 +237,11 @@ public record NatsMsgSchedule
 
         if (TimeZone is { } timeZone)
         {
+            if (string.IsNullOrWhiteSpace(timeZone))
+            {
+                throw new ArgumentException("TimeZone cannot be empty or whitespace.", nameof(TimeZone));
+            }
+
             if (Schedule.StartsWith("@at ", StringComparison.Ordinal) ||
                 Schedule.StartsWith("@every ", StringComparison.Ordinal))
             {

--- a/src/Synadia.Orbit.JetStream.Extensions/Models/NatsMsgSchedule.cs
+++ b/src/Synadia.Orbit.JetStream.Extensions/Models/NatsMsgSchedule.cs
@@ -13,12 +13,12 @@ namespace Synadia.Orbit.JetStream.Extensions.Models;
 /// at a future time to a target subject within the same stream.</para>
 /// <para>Supported schedule types:</para>
 /// <list type="bullet">
-/// <item><c>@at</c> — one-time delivery at a specific time (NATS Server 2.12+)</item>
-/// <item><c>@every</c> — repeating delivery at a fixed interval (NATS Server 2.14+)</item>
+/// <item><c>@at</c>, one-time delivery at a specific time (NATS Server 2.12+)</item>
+/// <item><c>@every</c>, repeating delivery at a fixed interval (NATS Server 2.14+)</item>
+/// <item>Cron expressions and predefined schedules (<c>@hourly</c>, <c>@daily</c>, ...) (NATS Server 2.14+)</item>
 /// </list>
-/// <para>Cron expressions are defined in <see href="https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-51.md">ADR-51</see>
-/// but not yet implemented in the server. Use the <see cref="NatsMsgSchedule(string, string)"/> constructor
-/// for forward compatibility with future schedule types.</para>
+/// <para>See <see href="https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-51.md">ADR-51</see>
+/// for the full schedule specification.</para>
 /// </remarks>
 public record NatsMsgSchedule
 {
@@ -26,6 +26,7 @@ public record NatsMsgSchedule
     private const string NatsScheduleTargetHeader = "Nats-Schedule-Target";
     private const string NatsScheduleSourceHeader = "Nats-Schedule-Source";
     private const string NatsScheduleTtlHeader = "Nats-Schedule-TTL";
+    private const string NatsScheduleTimeZoneHeader = "Nats-Schedule-Time-Zone";
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NatsMsgSchedule"/> class with a one-time <c>@at</c> schedule.
@@ -81,10 +82,12 @@ public record NatsMsgSchedule
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NatsMsgSchedule"/> class with a raw schedule expression.
-    /// Use this constructor for forward compatibility with future schedule types (e.g. cron expressions).
+    /// Accepts cron expressions, predefined schedules (<c>@hourly</c>, <c>@daily</c>, ...),
+    /// or any other schedule string the server understands.
     /// </summary>
-    /// <param name="schedule">The schedule expression. Currently the server supports <c>@at</c> (2.12+)
-    /// and <c>@every</c> (2.14+). Cron expressions are planned but not yet implemented server-side.</param>
+    /// <param name="schedule">The schedule expression. Supported forms: <c>@at &lt;rfc3339&gt;</c> (2.12+),
+    /// <c>@every &lt;duration&gt;</c> (2.14+), 6-field cron (<c>"0 0 * * * *"</c>) (2.14+),
+    /// or predefined schedules <c>@yearly</c>/<c>@annually</c>/<c>@monthly</c>/<c>@weekly</c>/<c>@daily</c>/<c>@midnight</c>/<c>@hourly</c> (2.14+).</param>
     /// <param name="target">The target subject for message delivery.</param>
     /// <exception cref="ArgumentException">Thrown when schedule or target is null or whitespace.</exception>
     public NatsMsgSchedule(string schedule, string target)
@@ -117,8 +120,8 @@ public record NatsMsgSchedule
     /// Gets the raw schedule expression.
     /// </summary>
     /// <remarks>
-    /// Currently supported by the server: <c>@at</c> (2.12+) and <c>@every</c> (2.14+).
-    /// Cron expressions are planned in ADR-51 but not yet implemented server-side.
+    /// Server-supported forms: <c>@at</c> (2.12+), <c>@every</c> (2.14+), 6-field cron expressions (2.14+),
+    /// and predefined schedules <c>@yearly</c>/<c>@annually</c>/<c>@monthly</c>/<c>@weekly</c>/<c>@daily</c>/<c>@midnight</c>/<c>@hourly</c> (2.14+).
     /// </remarks>
     public string Schedule { get; }
 
@@ -152,11 +155,59 @@ public record NatsMsgSchedule
     public string? Source { get; init; }
 
     /// <summary>
+    /// Gets the optional time zone for cron schedules. Requires NATS Server 2.14 or later.
+    /// </summary>
+    /// <remarks>
+    /// Accepted values are those Go's <c>time.LoadLocation()</c> understands: an IANA Time Zone database name
+    /// (<c>America/New_York</c>, <c>Europe/Amsterdam</c>, <c>Asia/Tokyo</c>), the literal <c>UTC</c>
+    /// (equivalent to omitting the header), or the literal <c>Local</c> (uses the server's local time zone).
+    /// Fixed offsets like <c>+02:00</c> and abbreviations like <c>EST</c> are not accepted.
+    /// Only allowed on cron schedules; setting it together with <c>@at</c> or <c>@every</c> causes
+    /// <see cref="ToHeaders"/> to throw.
+    /// </remarks>
+    public string? TimeZone { get; init; }
+
+    /// <summary>
+    /// Creates a schedule from a cron expression. Requires NATS Server 2.14 or later.
+    /// </summary>
+    /// <param name="cron">A 6-field cron expression (seconds minutes hours day-of-month month day-of-week).
+    /// Example: <c>"0 0 * * * *"</c> for the start of every hour.</param>
+    /// <param name="target">The target subject for message delivery.</param>
+    /// <returns>A new <see cref="NatsMsgSchedule"/> configured with the given cron expression.</returns>
+    public static NatsMsgSchedule Cron(string cron, string target) => new(cron, target);
+
+    /// <summary>Creates a schedule that fires once a year at midnight on January 1st (UTC by default). Requires NATS Server 2.14 or later.</summary>
+    /// <param name="target">The target subject for message delivery.</param>
+    /// <returns>A new <see cref="NatsMsgSchedule"/> configured with <c>@yearly</c>.</returns>
+    public static NatsMsgSchedule Yearly(string target) => new("@yearly", target);
+
+    /// <summary>Creates a schedule that fires once a month at midnight on the first of the month (UTC by default). Requires NATS Server 2.14 or later.</summary>
+    /// <param name="target">The target subject for message delivery.</param>
+    /// <returns>A new <see cref="NatsMsgSchedule"/> configured with <c>@monthly</c>.</returns>
+    public static NatsMsgSchedule Monthly(string target) => new("@monthly", target);
+
+    /// <summary>Creates a schedule that fires once a week at midnight between Saturday and Sunday (UTC by default). Requires NATS Server 2.14 or later.</summary>
+    /// <param name="target">The target subject for message delivery.</param>
+    /// <returns>A new <see cref="NatsMsgSchedule"/> configured with <c>@weekly</c>.</returns>
+    public static NatsMsgSchedule Weekly(string target) => new("@weekly", target);
+
+    /// <summary>Creates a schedule that fires once a day at midnight (UTC by default). Requires NATS Server 2.14 or later.</summary>
+    /// <param name="target">The target subject for message delivery.</param>
+    /// <returns>A new <see cref="NatsMsgSchedule"/> configured with <c>@daily</c>.</returns>
+    public static NatsMsgSchedule Daily(string target) => new("@daily", target);
+
+    /// <summary>Creates a schedule that fires at the start of every hour (UTC by default). Requires NATS Server 2.14 or later.</summary>
+    /// <param name="target">The target subject for message delivery.</param>
+    /// <returns>A new <see cref="NatsMsgSchedule"/> configured with <c>@hourly</c>.</returns>
+    public static NatsMsgSchedule Hourly(string target) => new("@hourly", target);
+
+    /// <summary>
     /// Converts this schedule configuration to NATS headers.
     /// </summary>
     /// <param name="existingHeaders">Optional existing headers to merge with. If null, new headers are created.</param>
     /// <returns>A <see cref="NatsHeaders"/> instance containing the scheduling headers.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <see cref="Ttl"/> is less than 1 second and not <see cref="TimeSpan.MaxValue"/>.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="TimeZone"/> is set on a non-cron schedule (<c>@at</c> or <c>@every</c>).</exception>
     public NatsHeaders ToHeaders(NatsHeaders? existingHeaders = null)
     {
         var headers = existingHeaders ?? new NatsHeaders();
@@ -167,6 +218,18 @@ public record NatsMsgSchedule
         if (Source is { } source)
         {
             headers[NatsScheduleSourceHeader] = source;
+        }
+
+        if (TimeZone is { } timeZone)
+        {
+            if (Schedule.StartsWith("@at ", StringComparison.Ordinal) ||
+                Schedule.StartsWith("@every ", StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    "Nats-Schedule-Time-Zone is only valid on cron schedules; not allowed with @at or @every.");
+            }
+
+            headers[NatsScheduleTimeZoneHeader] = timeZone;
         }
 
         if (Ttl is { } ttl)

--- a/src/Synadia.Orbit.JetStream.Extensions/PACKAGE.md
+++ b/src/Synadia.Orbit.JetStream.Extensions/PACKAGE.md
@@ -54,10 +54,8 @@ for the full specification. The stream must have `AllowMsgSchedules = true`.
 | Delayed publish | `NatsMsgSchedule(DateTimeOffset, target)` | null | 2.12+ |
 | Recurring publish | `NatsMsgSchedule(TimeSpan, target)` | null | 2.14+ |
 | Data sampling | `NatsMsgSchedule(TimeSpan, target) { Source = ... }` | set | 2.14+ |
-
-> **Note:** Cron expressions and timezone support are defined in ADR-51 but not yet implemented
-> in the server. The `NatsMsgSchedule(string, string)` raw constructor is available for forward
-> compatibility with future schedule types.
+| Cron schedule | `NatsMsgSchedule.Cron("0 0 * * * *", target)` | null | 2.14+ |
+| Predefined schedule | `NatsMsgSchedule.Hourly(target)` etc. | null | 2.14+ |
 
 ### Delayed Publish (NATS Server 2.12+)
 
@@ -149,6 +147,40 @@ var schedule = new NatsMsgSchedule(DateTimeOffset.UtcNow.AddMinutes(10), "sensor
     Source = "sensors.raw",
 };
 ```
+
+### Cron Schedules (NATS Server 2.14+)
+
+Use a 6-field cron expression (seconds minutes hours day-of-month month day-of-week) or one of the
+predefined factory methods:
+
+```csharp
+// "At minute 0 of every hour"
+var schedule = NatsMsgSchedule.Cron("0 0 * * * *", "events.hourly");
+
+// Or use a predefined factory
+var schedule = NatsMsgSchedule.Hourly("events.hourly");
+
+await js.PublishScheduledAsync("scheduling.hourly", "payload", schedule);
+```
+
+Predefined factories: `Yearly`, `Monthly`, `Weekly`, `Daily`, `Hourly`. Raw aliases `@annually` and
+`@midnight` are also accepted via the string constructor.
+
+Cron schedules evaluate in UTC by default. Set `TimeZone` to an IANA name to evaluate in a specific
+zone:
+
+```csharp
+var schedule = NatsMsgSchedule.Cron("0 0 9 * * 1-5", "events.workday_open")
+{
+    TimeZone = "America/New_York",
+};
+```
+
+Accepted `TimeZone` values: an IANA name (`America/New_York`, `Europe/Amsterdam`, ...), `UTC`, or
+`Local` (server's local time zone). Fixed offsets like `+02:00` and abbreviations like `EST` are
+not accepted. The server resolves IANA names against its host's tzdata, so operators must keep
+tzdata installed and current. Setting `TimeZone` on an `@at` or `@every` schedule throws on
+`ToHeaders()`.
 
 ### TTL Options
 

--- a/tests/Synadia.Orbit.JetStream.Extensions.Test/SchedulingExtensionsTest.cs
+++ b/tests/Synadia.Orbit.JetStream.Extensions.Test/SchedulingExtensionsTest.cs
@@ -265,6 +265,143 @@ public class SchedulingExtensionsTest
     }
 
     [Fact]
+    public void NatsMsgSchedule_cron_factory_sets_raw_pattern()
+    {
+        var schedule = NatsMsgSchedule.Cron("0 0 * * * *", "events.target");
+
+        var headers = schedule.ToHeaders();
+
+        Assert.Equal("0 0 * * * *", headers["Nats-Schedule"]);
+        Assert.Equal("events.target", headers["Nats-Schedule-Target"]);
+        Assert.Null(schedule.ScheduleAt);
+        Assert.Null(schedule.Interval);
+    }
+
+    [Theory]
+    [InlineData("Yearly", "@yearly")]
+    [InlineData("Monthly", "@monthly")]
+    [InlineData("Weekly", "@weekly")]
+    [InlineData("Daily", "@daily")]
+    [InlineData("Hourly", "@hourly")]
+    public void NatsMsgSchedule_predefined_factory_sets_pattern(string factory, string expected)
+    {
+        NatsMsgSchedule schedule = factory switch
+        {
+            "Yearly" => NatsMsgSchedule.Yearly("events.target"),
+            "Monthly" => NatsMsgSchedule.Monthly("events.target"),
+            "Weekly" => NatsMsgSchedule.Weekly("events.target"),
+            "Daily" => NatsMsgSchedule.Daily("events.target"),
+            "Hourly" => NatsMsgSchedule.Hourly("events.target"),
+            _ => throw new ArgumentOutOfRangeException(nameof(factory)),
+        };
+
+        Assert.Equal(expected, schedule.ToHeaders()["Nats-Schedule"]);
+        Assert.Equal("events.target", schedule.Target);
+    }
+
+    [Fact]
+    public void NatsMsgSchedule_timezone_header_is_set_for_cron()
+    {
+        var schedule = NatsMsgSchedule.Hourly("events.target") with { TimeZone = "America/New_York" };
+
+        var headers = schedule.ToHeaders();
+
+        Assert.Equal("@hourly", headers["Nats-Schedule"]);
+        Assert.Equal("America/New_York", headers["Nats-Schedule-Time-Zone"]);
+    }
+
+    [Fact]
+    public void NatsMsgSchedule_timezone_omitted_when_null()
+    {
+        var schedule = NatsMsgSchedule.Hourly("events.target");
+
+        var headers = schedule.ToHeaders();
+
+        Assert.Empty(headers["Nats-Schedule-Time-Zone"].ToArray());
+    }
+
+    [Fact]
+    public void NatsMsgSchedule_timezone_rejected_on_at_schedule()
+    {
+        var schedule = new NatsMsgSchedule(DateTimeOffset.UtcNow.AddMinutes(5), "events.target")
+        {
+            TimeZone = "Europe/Amsterdam",
+        };
+
+        Assert.Throws<InvalidOperationException>(() => schedule.ToHeaders());
+    }
+
+    [Fact]
+    public void NatsMsgSchedule_timezone_rejected_on_every_schedule()
+    {
+        var schedule = new NatsMsgSchedule(TimeSpan.FromMinutes(5), "events.target")
+        {
+            TimeZone = "UTC",
+        };
+
+        Assert.Throws<InvalidOperationException>(() => schedule.ToHeaders());
+    }
+
+    [Fact]
+    public async Task Cron_schedule_should_publish_to_target()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectRetryAsync();
+
+        if (!connection.HasMinServerVersion(2, 14))
+        {
+            _output.WriteLine($"Skipping test - server version {connection.ServerInfo?.Version} does not support cron schedules (requires 2.14+)");
+            return;
+        }
+
+        INatsJSContext js = connection.CreateJetStreamContext();
+        string prefix = _server.GetNextId();
+
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        var streamConfig = new StreamConfig($"{prefix}s1", [$"{prefix}foo.*"])
+        {
+            AllowMsgSchedules = true,
+            AllowDirect = true,
+        };
+
+        await js.CreateStreamAsync(streamConfig, ct);
+
+        // Cron expression "* * * * * *" fires every second.
+        var schedule = NatsMsgSchedule.Cron("* * * * * *", $"{prefix}foo.publish");
+
+        var ack = await js.PublishScheduledAsync(
+            $"{prefix}foo.schedule",
+            "cron-payload",
+            schedule,
+            cancellationToken: ct);
+
+        ack.EnsureSuccess();
+
+        var stream = await js.GetStreamAsync($"{prefix}s1", cancellationToken: ct);
+        await WaitUntilAsync(
+            async () =>
+            {
+                await stream.RefreshAsync(ct).ConfigureAwait(false);
+                return stream.Info.State.Messages >= 2;
+            },
+            TimeSpan.FromSeconds(10),
+            ct);
+
+        var msg = await stream.GetDirectAsync<string>(
+            new StreamMsgGetRequest { LastBySubj = $"{prefix}foo.publish" },
+            cancellationToken: ct);
+
+        Assert.Equal("cron-payload", msg.Data);
+        Assert.NotNull(msg.Headers);
+        Assert.Equal($"{prefix}foo.schedule", msg.Headers["Nats-Scheduler"].ToString());
+
+        // Cron schedules carry an RFC3339 timestamp for the next firing (not "purge").
+        Assert.NotEqual("purge", msg.Headers["Nats-Schedule-Next"].ToString());
+        Assert.False(string.IsNullOrEmpty(msg.Headers["Nats-Schedule-Next"].ToString()));
+    }
+
+    [Fact]
     public async Task PublishScheduledAsync_publishes_message_with_schedule_headers()
     {
         // Arrange

--- a/tests/Synadia.Orbit.JetStream.Extensions.Test/SchedulingExtensionsTest.cs
+++ b/tests/Synadia.Orbit.JetStream.Extensions.Test/SchedulingExtensionsTest.cs
@@ -321,6 +321,23 @@ public class SchedulingExtensionsTest
     }
 
     [Fact]
+    public void NatsMsgSchedule_cron_factory_rejects_at_and_every()
+    {
+        Assert.Throws<ArgumentException>(() => NatsMsgSchedule.Cron("@at 1970-01-01T00:00:00Z", "events.target"));
+        Assert.Throws<ArgumentException>(() => NatsMsgSchedule.Cron("@every 5m", "events.target"));
+    }
+
+    [Fact]
+    public void NatsMsgSchedule_timezone_rejects_empty_or_whitespace()
+    {
+        var emptyTz = NatsMsgSchedule.Hourly("events.target") with { TimeZone = string.Empty };
+        Assert.Throws<ArgumentException>(() => emptyTz.ToHeaders());
+
+        var whitespaceTz = NatsMsgSchedule.Hourly("events.target") with { TimeZone = "   " };
+        Assert.Throws<ArgumentException>(() => whitespaceTz.ToHeaders());
+    }
+
+    [Fact]
     public void NatsMsgSchedule_timezone_rejected_on_at_schedule()
     {
         var schedule = new NatsMsgSchedule(DateTimeOffset.UtcNow.AddMinutes(5), "events.target")


### PR DESCRIPTION
Adds cron schedule support to `NatsMsgSchedule` per ADR-51 rev 7. New `TimeZone` init property serializes to `Nats-Schedule-Time-Zone` and is rejected on `@at` / `@every` schedules. Predefined-schedule factories (`Yearly`, `Monthly`, `Weekly`, `Daily`, `Hourly`) and a `Cron(expr, target)` factory cover the common cases; the existing string constructor still works for raw expressions and aliases like `@annually` / `@midnight`. Integration test verified against `nats-server v2.14.0-RC.1`.