### PR TITLE
Release JetStream.Extensions 1.0.0-preview.5

### DIFF
--- a/src/Synadia.Orbit.JetStream.Extensions/version.txt
+++ b/src/Synadia.Orbit.JetStream.Extensions/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.4
+1.0.0-preview.5


### PR DESCRIPTION
Release JetStream.Extensions 1.0.0-preview.5. Adds cron and predefined schedule support (NATS Server 2.14+) and updates the scheduled-source fallback test for ADR-51 rev 5.

- Add cron schedule support (#58)
- tests: update scheduled source fallback test for ADR-51 rev 5 (#52)