### PR TITLE
Add JetStream fast-ingest batch publisher

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <NatsVersion>2.7.3</NatsVersion>
+    <NatsVersion>2.8.0-preview.2</NatsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="NATS.Net" Version="$(NatsVersion)" />

--- a/src/Synadia.Orbit.JetStream.Publisher/BatchPublishHelper.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/BatchPublishHelper.cs
@@ -133,4 +133,25 @@ internal static class BatchPublishHelper
         return JsonSerializer.Deserialize<BatchPublishAckResponse>(data);
 #endif
     }
+
+    internal static NatsHeaders CloneAndApplyMsgOpts(NatsHeaders? src, NatsJSBatchMsgOpts? opts)
+    {
+        var headers = CloneHeaders(src);
+        ApplyBatchMessageOptions(headers, opts);
+        return headers;
+    }
+
+    internal static Exception FastPublishExceptionFor(BatchPublishErrorResponse err)
+    {
+        var apiError = new ApiError { Code = err.Code, ErrCode = err.ErrCode, Description = err.Description };
+        return err.ErrCode switch
+        {
+            NatsJSFastPublishException.ErrCodeNotEnabled => new NatsJSFastPublishException(apiError),
+            NatsJSFastPublishException.ErrCodeInvalidPattern => new NatsJSFastPublishException(apiError),
+            NatsJSFastPublishException.ErrCodeInvalidId => new NatsJSFastPublishException(apiError),
+            NatsJSFastPublishException.ErrCodeUnknownId => new NatsJSFastPublishException(apiError),
+            NatsJSFastPublishException.ErrCodeTooManyInflight => new NatsJSFastPublishException(apiError),
+            _ => new NatsJSApiException(apiError),
+        };
+    }
 }

--- a/src/Synadia.Orbit.JetStream.Publisher/FastPublishJsonSerializerContext.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/FastPublishJsonSerializerContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 #pragma warning disable SA1600 // Elements should be documented (internal types)
+#pragma warning disable SA1402 // File may only contain a single type
 
 using System.Text.Json.Serialization;
 
@@ -15,13 +16,8 @@ namespace Synadia.Orbit.JetStream.Publisher;
 [JsonSerializable(typeof(FastPublishErrResponse))]
 internal partial class FastPublishJsonSerializerContext : JsonSerializerContext;
 
-#pragma warning disable SA1402
-
 internal record FastPublishFlowAckResponse
 {
-    [JsonPropertyName("type")]
-    public string? Type { get; init; }
-
     [JsonPropertyName("seq")]
     public ulong Seq { get; init; }
 
@@ -31,9 +27,6 @@ internal record FastPublishFlowAckResponse
 
 internal record FastPublishGapResponse
 {
-    [JsonPropertyName("type")]
-    public string? Type { get; init; }
-
     [JsonPropertyName("last_seq")]
     public ulong LastSeq { get; init; }
 
@@ -43,9 +36,6 @@ internal record FastPublishGapResponse
 
 internal record FastPublishErrResponse
 {
-    [JsonPropertyName("type")]
-    public string? Type { get; init; }
-
     [JsonPropertyName("seq")]
     public ulong Seq { get; init; }
 

--- a/src/Synadia.Orbit.JetStream.Publisher/FastPublishJsonSerializerContext.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/FastPublishJsonSerializerContext.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+#pragma warning disable SA1600 // Elements should be documented (internal types)
+
+using System.Text.Json.Serialization;
+
+namespace Synadia.Orbit.JetStream.Publisher;
+
+/// <summary>
+/// Source-generated JSON serialization context for fast-ingest batch publish response types.
+/// </summary>
+[JsonSerializable(typeof(FastPublishFlowAckResponse))]
+[JsonSerializable(typeof(FastPublishGapResponse))]
+[JsonSerializable(typeof(FastPublishErrResponse))]
+internal partial class FastPublishJsonSerializerContext : JsonSerializerContext;
+
+#pragma warning disable SA1402
+
+internal record FastPublishFlowAckResponse
+{
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
+
+    [JsonPropertyName("seq")]
+    public ulong Seq { get; init; }
+
+    [JsonPropertyName("msgs")]
+    public ushort Messages { get; init; }
+}
+
+internal record FastPublishGapResponse
+{
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
+
+    [JsonPropertyName("last_seq")]
+    public ulong LastSeq { get; init; }
+
+    [JsonPropertyName("seq")]
+    public ulong Seq { get; init; }
+}
+
+internal record FastPublishErrResponse
+{
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
+
+    [JsonPropertyName("seq")]
+    public ulong Seq { get; init; }
+
+    [JsonPropertyName("error")]
+    public BatchPublishErrorResponse? Error { get; init; }
+}

--- a/src/Synadia.Orbit.JetStream.Publisher/INatsJSFastPublisher.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/INatsJSFastPublisher.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using NATS.Client.Core;
+
+namespace Synadia.Orbit.JetStream.Publisher;
+
+/// <summary>
+/// Provides methods for fast-ingest batch publishing to a stream (ADR-50).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Fast-ingest delivers high-throughput batch publishing without atomicity. Unlike
+/// <see cref="INatsJSBatchPublisher"/>, individual messages may be lost (gaps) and a partial
+/// batch may persist. The server enforces flow control: <c>AddAsync</c>/<c>AddMsgAsync</c>
+/// stall until acks arrive when the configured <see cref="NatsJSFastPublishFlowControl.MaxOutstandingAcks"/>
+/// window is exceeded.
+/// </para>
+/// <para>
+/// This type is NOT thread-safe. <c>AddAsync</c>, <c>AddMsgAsync</c>, <c>CommitAsync</c>,
+/// <c>CommitMsgAsync</c>, and <c>CloseAsync</c> must be called sequentially by a single
+/// producer.
+/// </para>
+/// <para>
+/// Disposing without <c>CommitAsync</c>/<c>CommitMsgAsync</c>/<c>CloseAsync</c> closes the
+/// publisher locally; the server's batch timeout (10s of inactivity) abandons the batch.
+/// </para>
+/// <para>
+/// Requires <c>StreamConfig.AllowBatchPublish = true</c> and nats-server v2.14.0+.
+/// </para>
+/// </remarks>
+public interface INatsJSFastPublisher : IAsyncDisposable
+{
+    /// <summary>
+    /// Gets the number of messages added to the batch so far.
+    /// </summary>
+    long Size { get; }
+
+    /// <summary>
+    /// Gets the highest batch sequence the server has acknowledged so far.
+    /// </summary>
+    long AckSequence { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the batch has been committed, closed, or terminated by error.
+    /// </summary>
+    bool IsClosed { get; }
+
+    /// <summary>
+    /// Publishes a message to the batch with the given subject and data.
+    /// </summary>
+    /// <typeparam name="T">The payload type.</typeparam>
+    /// <param name="subject">The subject to publish to.</param>
+    /// <param name="data">The message data.</param>
+    /// <param name="opts">Optional per-message options.</param>
+    /// <param name="serializer">Optional serializer; when null, the connection's registered serializer is used.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The per-message ack with the local batch sequence and the highest server-acked sequence so far.</returns>
+    Task<NatsJSFastPubAck> AddAsync<T>(string subject, T data, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Publishes a message to the batch.
+    /// </summary>
+    /// <typeparam name="T">The payload type.</typeparam>
+    /// <param name="msg">The message.</param>
+    /// <param name="opts">Optional per-message options.</param>
+    /// <param name="serializer">Optional serializer; when null, the connection's registered serializer is used.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The per-message ack with the local batch sequence and the highest server-acked sequence so far.</returns>
+    Task<NatsJSFastPubAck> AddMsgAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Publishes the final message and commits the batch.
+    /// </summary>
+    /// <typeparam name="T">The payload type.</typeparam>
+    /// <param name="subject">The subject to publish to.</param>
+    /// <param name="data">The message data.</param>
+    /// <param name="opts">Optional per-message options.</param>
+    /// <param name="serializer">Optional serializer; when null, the connection's registered serializer is used.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The batch ack.</returns>
+    Task<NatsJSBatchAck> CommitAsync<T>(string subject, T data, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Publishes the final message and commits the batch.
+    /// </summary>
+    /// <typeparam name="T">The payload type.</typeparam>
+    /// <param name="msg">The final message.</param>
+    /// <param name="opts">Optional per-message options.</param>
+    /// <param name="serializer">Optional serializer; when null, the connection's registered serializer is used.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The batch ack.</returns>
+    Task<NatsJSBatchAck> CommitMsgAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Closes the batch (end-of-batch commit) without storing a final message. The batch must
+    /// contain at least one message.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The batch ack.</returns>
+    Task<NatsJSBatchAck> CloseAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsClientExtensions.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsClientExtensions.cs
@@ -15,6 +15,13 @@ public static class NatsClientExtensions
         return new JetStreamPublisher<T>(client.Connection);
     }
 
+    /// <summary>
+    /// Creates a fast-ingest batch publisher for high-throughput, non-atomic batch publishing.
+    /// Requires NATS Server 2.14+ and <c>StreamConfig.AllowBatchPublish = true</c>.
+    /// </summary>
+    /// <param name="js">The JetStream context.</param>
+    /// <param name="opts">Optional publisher options.</param>
+    /// <returns>The fast-ingest batch publisher.</returns>
     public static NatsJSFastPublisher CreateOrbitFastPublisher(this INatsJSContext js, NatsJSFastPublisherOpts? opts = null)
     {
         return new NatsJSFastPublisher(js, opts);

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsClientExtensions.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsClientExtensions.cs
@@ -4,6 +4,7 @@
 #pragma warning disable
 
 using NATS.Client.Core;
+using NATS.Client.JetStream;
 
 namespace Synadia.Orbit.JetStream.Publisher;
 
@@ -12,5 +13,10 @@ public static class NatsClientExtensions
     public static JetStreamPublisher<T> CreateOrbitJetStreamPublisher<T>(this INatsClient client)
     {
         return new JetStreamPublisher<T>(client.Connection);
+    }
+
+    public static NatsJSFastPublisher CreateOrbitFastPublisher(this INatsJSContext js, NatsJSFastPublisherOpts? opts = null)
+    {
+        return new NatsJSFastPublisher(js, opts);
     }
 }

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPubAck.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPubAck.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Synadia.Orbit.JetStream.Publisher;
+
+/// <summary>
+/// The acknowledgment returned by <see cref="INatsJSFastPublisher.AddAsync{T}"/> and
+/// <see cref="INatsJSFastPublisher.AddMsgAsync{T}"/>.
+/// </summary>
+public record NatsJSFastPubAck
+{
+    /// <summary>
+    /// Gets the sequence of this message within the batch.
+    /// </summary>
+    public long BatchSequence { get; init; }
+
+    /// <summary>
+    /// Gets the highest batch sequence that the server has acknowledged so far.
+    /// With <see cref="NatsJSFastPublisherOpts.ContinueOnGap"/> = false, all messages up to and
+    /// including this sequence were persisted. With <see cref="NatsJSFastPublisherOpts.ContinueOnGap"/>
+    /// = true, persistence may be incomplete (gaps reported via the error handler).
+    /// </summary>
+    public long AckSequence { get; init; }
+}

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPublishException.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPublishException.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using NATS.Client.JetStream;
+using NATS.Client.JetStream.Models;
+
+namespace Synadia.Orbit.JetStream.Publisher;
+
+/// <summary>
+/// Exception thrown when the server returns an API error for a fast-ingest batch publish.
+/// </summary>
+public class NatsJSFastPublishException : NatsJSApiException
+{
+    /// <summary>
+    /// Error code indicating fast batch publish is not enabled on the stream.
+    /// </summary>
+    public const int ErrCodeNotEnabled = 10203;
+
+    /// <summary>
+    /// Error code indicating an invalid reply subject pattern was used.
+    /// </summary>
+    public const int ErrCodeInvalidPattern = 10204;
+
+    /// <summary>
+    /// Error code indicating the batch ID is invalid (exceeds 64 characters).
+    /// </summary>
+    public const int ErrCodeInvalidId = 10205;
+
+    /// <summary>
+    /// Error code indicating the batch ID is unknown to the server.
+    /// </summary>
+    public const int ErrCodeUnknownId = 10206;
+
+    /// <summary>
+    /// Error code indicating the server has too many in-flight fast batch publishes.
+    /// </summary>
+    public const int ErrCodeTooManyInflight = 10211;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NatsJSFastPublishException"/> class.
+    /// </summary>
+    /// <param name="error">The API error returned by the server.</param>
+    public NatsJSFastPublishException(ApiError error)
+        : base(error)
+    {
+    }
+}

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPublishFlowControl.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPublishFlowControl.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Synadia.Orbit.JetStream.Publisher;
+
+/// <summary>
+/// Configures flow control for fast batch publishing.
+/// </summary>
+public record NatsJSFastPublishFlowControl
+{
+    /// <summary>
+    /// Gets the initial flow value (server ack frequency, in messages). Server may adjust this
+    /// dynamically. Default: 100.
+    /// </summary>
+    public ushort Flow { get; init; } = 100;
+
+    /// <summary>
+    /// Gets the maximum number of unacknowledged flow windows before <c>AddAsync</c>/
+    /// <c>AddMsgAsync</c> stall awaiting an ack. Default: 2.
+    /// </summary>
+    public ushort MaxOutstandingAcks { get; init; } = 2;
+
+    /// <summary>
+    /// Gets the timeout for waiting on flow acks. When null, the JetStream context default
+    /// timeout is used.
+    /// </summary>
+    public TimeSpan? AckTimeout { get; init; }
+}

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPublishGapException.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPublishGapException.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Synadia.Orbit.JetStream.Publisher;
+
+/// <summary>
+/// Reports a gap detected by the server during fast-ingest batch publish.
+/// </summary>
+/// <remarks>
+/// Surfaced via <see cref="NatsJSFastPublisherOpts.ErrorHandler"/> when
+/// <see cref="NatsJSFastPublisherOpts.ContinueOnGap"/> is enabled.
+/// </remarks>
+public class NatsJSFastPublishGapException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NatsJSFastPublishGapException"/> class.
+    /// </summary>
+    /// <param name="expectedLastSequence">The sequence the server expected to receive next.</param>
+    /// <param name="currentSequence">The sequence that triggered the gap.</param>
+    public NatsJSFastPublishGapException(long expectedLastSequence, long currentSequence)
+        : base($"fast batch gap detected: expected last sequence {expectedLastSequence}, current sequence {currentSequence}")
+    {
+        ExpectedLastSequence = expectedLastSequence;
+        CurrentSequence = currentSequence;
+    }
+
+    /// <summary>
+    /// Gets the sequence the server expected to receive next.
+    /// </summary>
+    public long ExpectedLastSequence { get; }
+
+    /// <summary>
+    /// Gets the sequence that triggered the gap.
+    /// </summary>
+    public long CurrentSequence { get; }
+}

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPublishMessageException.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPublishMessageException.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using NATS.Client.JetStream;
+using NATS.Client.JetStream.Models;
+
+namespace Synadia.Orbit.JetStream.Publisher;
+
+/// <summary>
+/// Reports a per-message error returned by the server during fast-ingest batch publish.
+/// </summary>
+/// <remarks>
+/// Surfaced via <see cref="NatsJSFastPublisherOpts.ErrorHandler"/>. Note that fast-ingest
+/// does not guarantee whether messages up to this sequence were persisted.
+/// </remarks>
+public class NatsJSFastPublishMessageException : NatsJSApiException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NatsJSFastPublishMessageException"/> class.
+    /// </summary>
+    /// <param name="sequence">The sequence at which the error occurred.</param>
+    /// <param name="error">The API error returned by the server.</param>
+    public NatsJSFastPublishMessageException(long sequence, ApiError error)
+        : base(error)
+    {
+        Sequence = sequence;
+    }
+
+    /// <summary>
+    /// Gets the sequence at which the error occurred.
+    /// </summary>
+    public long Sequence { get; }
+}

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPublisher.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPublisher.cs
@@ -1,0 +1,821 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Globalization;
+using System.Text.Json;
+using NATS.Client.Core;
+using NATS.Client.JetStream;
+using NATS.Client.JetStream.Models;
+
+namespace Synadia.Orbit.JetStream.Publisher;
+
+/// <summary>
+/// Implementation of <see cref="INatsJSFastPublisher"/> for fast-ingest batch publishing per ADR-50.
+/// </summary>
+public sealed class NatsJSFastPublisher : INatsJSFastPublisher
+{
+    private const int OpStart = 0;
+    private const int OpAddMsg = 1;
+    private const int OpCommitMsg = 2;
+    private const int OpCommitEob = 3;
+    private const int OpPing = 4;
+
+    private const ushort DefaultFlow = 100;
+    private const ushort DefaultMaxOutstandingAcks = 2;
+
+    private static readonly byte[] TypeAckMarker = "\"type\":\"ack\""u8.ToArray();
+    private static readonly byte[] TypeGapMarker = "\"type\":\"gap\""u8.ToArray();
+    private static readonly byte[] TypeErrMarker = "\"type\":\"err\""u8.ToArray();
+
+    private readonly INatsJSContext _js;
+    private readonly INatsConnection _conn;
+    private readonly NatsJSFastPublisherOpts _opts;
+    private readonly ushort _maxOutstandingAcks;
+    private readonly TimeSpan _ackTimeout;
+    private readonly Action<Exception>? _errorHandler;
+    private readonly string _ackInboxPrefix;
+    private readonly string _gap;
+
+    private readonly object _lock = new();
+
+    private string _replyPrefix;
+    private ushort _flow;
+    private long _sequence;
+    private long _ackSequence;
+    private bool _closed;
+    private string? _batchSubject;
+
+    private INatsSub<byte[]>? _ackSub;
+    private CancellationTokenSource? _ackSubCts;
+    private Task? _ackReaderTask;
+
+    private TaskCompletionSource<FastPublishFlowAckResponse>? _firstAckTcs;
+    private TaskCompletionSource<BatchPublishAckResponse>? _commitTcs;
+    private TaskCompletionSource<bool>? _stallTcs;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NatsJSFastPublisher"/> class.
+    /// </summary>
+    /// <param name="js">The JetStream context.</param>
+    /// <param name="opts">Optional publisher options.</param>
+    public NatsJSFastPublisher(INatsJSContext js, NatsJSFastPublisherOpts? opts = null)
+    {
+        _js = js;
+        _conn = js.Connection;
+        _opts = opts ?? new NatsJSFastPublisherOpts();
+        var fc = _opts.FlowControl ?? new NatsJSFastPublishFlowControl();
+        _flow = fc.Flow > 0 ? fc.Flow : DefaultFlow;
+        _maxOutstandingAcks = fc.MaxOutstandingAcks > 0 ? fc.MaxOutstandingAcks : DefaultMaxOutstandingAcks;
+        _ackTimeout = fc.AckTimeout ?? js.Opts.RequestTimeout;
+        _errorHandler = _opts.ErrorHandler;
+        _gap = _opts.ContinueOnGap ? "ok" : "fail";
+
+        // Use a non-_INBOX prefix because nats.net dispatches inbox subjects via an exact-match
+        // map (with a connection-level _INBOX.<connId>.* wildcard), which would not deliver the
+        // multi-token fast-ingest reply subjects.
+        _ackInboxPrefix = "_FB." + Nuid.NewNuid();
+        _replyPrefix = BuildReplyPrefix(_ackInboxPrefix, _flow, _gap);
+    }
+
+    /// <inheritdoc />
+    public long Size
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _sequence;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public long AckSequence
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _ackSequence;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public bool IsClosed
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _closed;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<NatsJSFastPubAck> AddAsync<T>(string subject, T data, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default)
+    {
+        var msg = new NatsMsg<T> { Subject = subject, Data = data };
+        return AddMsgInternalAsync(msg, opts, serializer, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<NatsJSFastPubAck> AddMsgAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default)
+        => AddMsgInternalAsync(msg, opts, serializer, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<NatsJSBatchAck> CommitAsync<T>(string subject, T data, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default)
+    {
+        var msg = new NatsMsg<T> { Subject = subject, Data = data };
+        return CommitMsgInternalAsync(msg, opts, serializer, eob: false, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<NatsJSBatchAck> CommitMsgAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default)
+        => CommitMsgInternalAsync(msg, opts, serializer, eob: false, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<NatsJSBatchAck> CloseAsync(CancellationToken cancellationToken = default)
+    {
+        string subject;
+        lock (_lock)
+        {
+            if (_closed)
+            {
+                throw new NatsJSBatchClosedException();
+            }
+
+            if (_sequence == 0 || _batchSubject == null)
+            {
+                throw new InvalidOperationException("Cannot close an empty batch");
+            }
+
+            subject = _batchSubject;
+        }
+
+        var msg = new NatsMsg<byte[]> { Subject = subject };
+        return CommitMsgInternalAsync<byte[]>(msg, opts: null, serializer: null, eob: true, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        TaskCompletionSource<FastPublishFlowAckResponse>? firstTcs;
+        TaskCompletionSource<BatchPublishAckResponse>? commitTcs;
+        TaskCompletionSource<bool>? stallTcs;
+        CancellationTokenSource? cts;
+        INatsSub<byte[]>? sub;
+        Task? readerTask;
+
+        lock (_lock)
+        {
+            _closed = true;
+            firstTcs = _firstAckTcs;
+            commitTcs = _commitTcs;
+            stallTcs = _stallTcs;
+            cts = _ackSubCts;
+            sub = _ackSub;
+            readerTask = _ackReaderTask;
+            _firstAckTcs = null;
+            _commitTcs = null;
+            _stallTcs = null;
+            _ackSub = null;
+            _ackSubCts = null;
+            _ackReaderTask = null;
+        }
+
+        firstTcs?.TrySetCanceled();
+        commitTcs?.TrySetCanceled();
+        stallTcs?.TrySetResult(true);
+
+        try
+        {
+            cts?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+
+        if (sub != null)
+        {
+            try
+            {
+                await sub.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        if (readerTask != null)
+        {
+            try
+            {
+                await readerTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        cts?.Dispose();
+    }
+
+    private static string BuildReplyPrefix(string inbox, ushort flow, string gap)
+        => inbox + "." + flow.ToString(CultureInfo.InvariantCulture) + "." + gap + ".";
+
+    private string BuildReplySubject(long seq, int operation)
+        => _replyPrefix + seq.ToString(CultureInfo.InvariantCulture) + "." + operation.ToString(CultureInfo.InvariantCulture) + ".$FI";
+
+    private async Task<NatsJSFastPubAck> AddMsgInternalAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts, INatsSerialize<T>? serializer, CancellationToken cancellationToken)
+    {
+        var owned = msg.Data as IDisposable;
+        try
+        {
+            NatsHeaders headers;
+            long seq;
+            int operation;
+            string reply;
+            bool isFirst;
+            TaskCompletionSource<FastPublishFlowAckResponse>? firstTcs = null;
+            TaskCompletionSource<bool>? stallTcs = null;
+            bool waitForAck;
+
+            lock (_lock)
+            {
+                if (_closed)
+                {
+                    throw new NatsJSBatchClosedException();
+                }
+
+                headers = BatchPublishHelper.CloneAndApplyMsgOpts(msg.Headers, opts);
+
+                _sequence++;
+                seq = _sequence;
+                isFirst = seq == 1;
+                operation = isFirst ? OpStart : OpAddMsg;
+                reply = BuildReplySubject(seq, operation);
+
+                if (isFirst)
+                {
+                    firstTcs = new TaskCompletionSource<FastPublishFlowAckResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    _firstAckTcs = firstTcs;
+                    _batchSubject = msg.Subject;
+                }
+
+                waitForAck = !isFirst && (long)_ackSequence + ((long)_flow * _maxOutstandingAcks) < seq;
+                if (waitForAck)
+                {
+                    _stallTcs ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    stallTcs = _stallTcs;
+                }
+            }
+
+            if (isFirst)
+            {
+                await EnsureAckSubscriptionAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (waitForAck && stallTcs != null)
+            {
+                await WaitForStallAsync(stallTcs, cancellationToken).ConfigureAwait(false);
+            }
+
+            var msgToSend = msg with { Headers = headers, ReplyTo = reply };
+
+            try
+            {
+                owned = null;
+                await _conn.PublishAsync(msgToSend, serializer, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                if (isFirst)
+                {
+                    CloseOnError();
+                }
+
+                throw;
+            }
+
+            if (isFirst && firstTcs != null)
+            {
+                FastPublishFlowAckResponse firstAck;
+                using var cts = cancellationToken.CanBeCanceled
+                    ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+                    : new CancellationTokenSource();
+                cts.CancelAfter(_ackTimeout);
+
+                using (cts.Token.Register(static state => ((TaskCompletionSource<FastPublishFlowAckResponse>)state!).TrySetCanceled(), firstTcs))
+                {
+                    try
+                    {
+                        firstAck = await firstTcs.Task.ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                    {
+                        CloseOnError();
+                        throw new TimeoutException($"Fast batch first message ack timeout after {_ackTimeout}");
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        CloseOnError();
+                        throw;
+                    }
+                }
+
+                long ackSeqLocal;
+                lock (_lock)
+                {
+                    _firstAckTcs = null;
+                    if (firstAck.Messages != 0 && firstAck.Messages != _flow)
+                    {
+                        _flow = firstAck.Messages;
+                        _replyPrefix = BuildReplyPrefix(_ackInboxPrefix, _flow, _gap);
+                    }
+
+                    _ackSequence = (long)firstAck.Seq;
+                    ackSeqLocal = _ackSequence;
+                }
+
+                return new NatsJSFastPubAck { BatchSequence = seq, AckSequence = ackSeqLocal };
+            }
+
+            long currentAckSeq;
+            lock (_lock)
+            {
+                currentAckSeq = _ackSequence;
+            }
+
+            return new NatsJSFastPubAck { BatchSequence = seq, AckSequence = currentAckSeq };
+        }
+        catch
+        {
+            owned?.Dispose();
+            throw;
+        }
+    }
+
+    private async Task<NatsJSBatchAck> CommitMsgInternalAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts, INatsSerialize<T>? serializer, bool eob, CancellationToken cancellationToken)
+    {
+        var owned = msg.Data as IDisposable;
+        try
+        {
+            NatsHeaders headers;
+            long seq;
+            int operation;
+            string reply;
+            bool needsSubscription;
+            TaskCompletionSource<BatchPublishAckResponse> commitTcs;
+            TaskCompletionSource<bool>? stallTcs = null;
+            bool waitForAck;
+
+            lock (_lock)
+            {
+                if (_closed)
+                {
+                    throw new NatsJSBatchClosedException();
+                }
+
+                headers = BatchPublishHelper.CloneAndApplyMsgOpts(msg.Headers, opts);
+                _sequence++;
+                seq = _sequence;
+                operation = eob ? OpCommitEob : OpCommitMsg;
+                reply = BuildReplySubject(seq, operation);
+
+                commitTcs = new TaskCompletionSource<BatchPublishAckResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _commitTcs = commitTcs;
+
+                needsSubscription = _ackSub == null;
+
+                waitForAck = (long)_ackSequence + ((long)_flow * _maxOutstandingAcks) < seq;
+                if (waitForAck)
+                {
+                    _stallTcs ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    stallTcs = _stallTcs;
+                }
+            }
+
+            if (needsSubscription)
+            {
+                await EnsureAckSubscriptionAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (waitForAck && stallTcs != null)
+            {
+                await WaitForStallAsync(stallTcs, cancellationToken).ConfigureAwait(false);
+            }
+
+            var msgToSend = msg with { Headers = headers, ReplyTo = reply };
+
+            try
+            {
+                owned = null;
+                await _conn.PublishAsync(msgToSend, serializer, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                CloseOnError();
+                throw;
+            }
+
+            using var cts = cancellationToken.CanBeCanceled
+                ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+                : new CancellationTokenSource();
+            cts.CancelAfter(_ackTimeout);
+
+            BatchPublishAckResponse commitAck;
+            using (cts.Token.Register(static state => ((TaskCompletionSource<BatchPublishAckResponse>)state!).TrySetCanceled(), commitTcs))
+            {
+                try
+                {
+                    commitAck = await commitTcs.Task.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                {
+                    CloseOnError();
+                    throw new TimeoutException($"Fast batch commit ack timeout after {_ackTimeout}");
+                }
+                catch (OperationCanceledException)
+                {
+                    CloseOnError();
+                    throw;
+                }
+            }
+
+            CloseOnError();
+
+            if (commitAck.Error != null)
+            {
+                throw BatchPublishHelper.FastPublishExceptionFor(commitAck.Error);
+            }
+
+            if (string.IsNullOrEmpty(commitAck.Stream))
+            {
+                throw new NatsJSInvalidBatchAckException();
+            }
+
+            return new NatsJSBatchAck
+            {
+                Stream = commitAck.Stream!,
+                Sequence = commitAck.Seq,
+                Domain = commitAck.Domain,
+                Value = commitAck.Value,
+                BatchId = commitAck.BatchId ?? string.Empty,
+                BatchSize = commitAck.BatchSize,
+            };
+        }
+        catch
+        {
+            owned?.Dispose();
+            throw;
+        }
+    }
+
+    private async Task EnsureAckSubscriptionAsync(CancellationToken cancellationToken)
+    {
+        INatsSub<byte[]> sub;
+        CancellationTokenSource cts;
+
+        lock (_lock)
+        {
+            if (_ackSub != null)
+            {
+                return;
+            }
+
+            cts = new CancellationTokenSource();
+            _ackSubCts = cts;
+        }
+
+        try
+        {
+            sub = await _conn.SubscribeCoreAsync<byte[]>(_ackInboxPrefix + ".>", cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            lock (_lock)
+            {
+                _ackSubCts = null;
+            }
+
+            cts.Dispose();
+            throw;
+        }
+
+        Task readerTask;
+        lock (_lock)
+        {
+            _ackSub = sub;
+            readerTask = Task.Run(() => AckReadLoopAsync(sub, cts.Token));
+            _ackReaderTask = readerTask;
+        }
+    }
+
+    private async Task AckReadLoopAsync(INatsSub<byte[]> sub, CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (await sub.Msgs.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                while (sub.Msgs.TryRead(out var ack))
+                {
+                    HandleAck(ack);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                _errorHandler?.Invoke(ex);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private void HandleAck(NatsMsg<byte[]> ack)
+    {
+        var data = ack.Data;
+        if (data == null || data.Length == 0)
+        {
+            return;
+        }
+
+        var span = new ReadOnlySpan<byte>(data);
+
+        if (span.IndexOf(new ReadOnlySpan<byte>(TypeGapMarker)) >= 0)
+        {
+            HandleGap(data);
+            return;
+        }
+
+        if (span.IndexOf(new ReadOnlySpan<byte>(TypeAckMarker)) >= 0)
+        {
+            HandleFlowAck(data);
+            return;
+        }
+
+        if (span.IndexOf(new ReadOnlySpan<byte>(TypeErrMarker)) >= 0)
+        {
+            HandleErr(data);
+            return;
+        }
+
+        HandleCommitAck(data);
+    }
+
+    private void HandleGap(byte[] data)
+    {
+        FastPublishGapResponse? gap;
+        try
+        {
+#if NET8_0_OR_GREATER
+            gap = JsonSerializer.Deserialize(data, FastPublishJsonSerializerContext.Default.FastPublishGapResponse);
+#else
+            gap = JsonSerializer.Deserialize<FastPublishGapResponse>(data);
+#endif
+        }
+        catch (Exception ex)
+        {
+            InvokeErrorHandler(ex);
+            return;
+        }
+
+        if (gap == null)
+        {
+            return;
+        }
+
+        InvokeErrorHandler(new NatsJSFastPublishGapException((long)gap.LastSeq, (long)gap.Seq));
+    }
+
+    private void HandleFlowAck(byte[] data)
+    {
+        FastPublishFlowAckResponse? flow;
+        try
+        {
+#if NET8_0_OR_GREATER
+            flow = JsonSerializer.Deserialize(data, FastPublishJsonSerializerContext.Default.FastPublishFlowAckResponse);
+#else
+            flow = JsonSerializer.Deserialize<FastPublishFlowAckResponse>(data);
+#endif
+        }
+        catch (Exception ex)
+        {
+            InvokeErrorHandler(ex);
+            return;
+        }
+
+        if (flow == null)
+        {
+            return;
+        }
+
+        TaskCompletionSource<FastPublishFlowAckResponse>? firstTcs = null;
+        TaskCompletionSource<bool>? stallTcs = null;
+
+        lock (_lock)
+        {
+            if (_firstAckTcs != null)
+            {
+                firstTcs = _firstAckTcs;
+                _firstAckTcs = null;
+                firstTcs.TrySetResult(flow);
+
+                // First ack updates state inside AddMsgInternalAsync continuation.
+                return;
+            }
+
+            if (flow.Messages != 0 && flow.Messages != _flow)
+            {
+                _flow = flow.Messages;
+                _replyPrefix = BuildReplyPrefix(_ackInboxPrefix, _flow, _gap);
+            }
+
+            _ackSequence = (long)flow.Seq;
+
+            if (_stallTcs != null)
+            {
+                stallTcs = _stallTcs;
+                _stallTcs = null;
+            }
+        }
+
+        stallTcs?.TrySetResult(true);
+    }
+
+    private void HandleErr(byte[] data)
+    {
+        FastPublishErrResponse? err;
+        try
+        {
+#if NET8_0_OR_GREATER
+            err = JsonSerializer.Deserialize(data, FastPublishJsonSerializerContext.Default.FastPublishErrResponse);
+#else
+            err = JsonSerializer.Deserialize<FastPublishErrResponse>(data);
+#endif
+        }
+        catch (Exception ex)
+        {
+            InvokeErrorHandler(ex);
+            return;
+        }
+
+        if (err?.Error == null)
+        {
+            return;
+        }
+
+        var apiError = new ApiError { Code = err.Error.Code, ErrCode = err.Error.ErrCode, Description = err.Error.Description };
+        InvokeErrorHandler(new NatsJSFastPublishMessageException((long)err.Seq, apiError));
+    }
+
+    private void HandleCommitAck(byte[] data)
+    {
+        BatchPublishAckResponse? commitAck;
+        try
+        {
+            commitAck = BatchPublishHelper.DeserializeAckResponse(data);
+        }
+        catch (Exception ex)
+        {
+            InvokeErrorHandler(ex);
+            return;
+        }
+
+        if (commitAck == null)
+        {
+            return;
+        }
+
+        TaskCompletionSource<BatchPublishAckResponse>? commitTcs;
+        lock (_lock)
+        {
+            commitTcs = _commitTcs;
+            _commitTcs = null;
+            _closed = true;
+        }
+
+        commitTcs?.TrySetResult(commitAck);
+    }
+
+    private async Task WaitForStallAsync(TaskCompletionSource<bool> stallTcs, CancellationToken cancellationToken)
+    {
+        var pingInterval = TimeSpan.FromMilliseconds(Math.Max(1, _ackTimeout.TotalMilliseconds / 3));
+
+        using var cts = cancellationToken.CanBeCanceled
+            ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+            : new CancellationTokenSource();
+        cts.CancelAfter(_ackTimeout);
+
+        using (cts.Token.Register(static state => ((TaskCompletionSource<bool>)state!).TrySetCanceled(), stallTcs))
+        {
+            while (true)
+            {
+                var pingDelay = Task.Delay(pingInterval, cts.Token);
+                var completed = await Task.WhenAny(stallTcs.Task, pingDelay).ConfigureAwait(false);
+                if (completed == stallTcs.Task)
+                {
+                    try
+                    {
+                        await stallTcs.Task.ConfigureAwait(false);
+                        return;
+                    }
+                    catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                    {
+                        CloseOnError();
+                        throw new TimeoutException($"Fast batch ack timeout after {_ackTimeout}");
+                    }
+                }
+
+                if (cts.IsCancellationRequested)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        throw new OperationCanceledException(cancellationToken);
+                    }
+
+                    CloseOnError();
+                    throw new TimeoutException($"Fast batch ack timeout after {_ackTimeout}");
+                }
+
+                await SendPingAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task SendPingAsync(CancellationToken cancellationToken)
+    {
+        long seq;
+        string? subject;
+        lock (_lock)
+        {
+            seq = _sequence;
+            subject = _batchSubject;
+        }
+
+        if (subject == null)
+        {
+            return;
+        }
+
+        var reply = BuildReplySubject(seq, OpPing);
+        var ping = new NatsMsg<byte[]> { Subject = subject, ReplyTo = reply };
+        try
+        {
+            await _conn.PublishAsync(ping, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            InvokeErrorHandler(ex);
+        }
+    }
+
+    private void CloseOnError()
+    {
+        TaskCompletionSource<FastPublishFlowAckResponse>? firstTcs;
+        TaskCompletionSource<BatchPublishAckResponse>? commitTcs;
+        TaskCompletionSource<bool>? stallTcs;
+
+        lock (_lock)
+        {
+            _closed = true;
+            firstTcs = _firstAckTcs;
+            commitTcs = _commitTcs;
+            stallTcs = _stallTcs;
+            _firstAckTcs = null;
+            _commitTcs = null;
+            _stallTcs = null;
+        }
+
+        firstTcs?.TrySetCanceled();
+        commitTcs?.TrySetCanceled();
+        stallTcs?.TrySetCanceled();
+    }
+
+    private void InvokeErrorHandler(Exception ex)
+    {
+        if (_errorHandler == null)
+        {
+            return;
+        }
+
+        try
+        {
+            _errorHandler(ex);
+        }
+        catch
+        {
+        }
+    }
+}

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPublisher.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPublisher.cs
@@ -378,6 +378,11 @@ public sealed class NatsJSFastPublisher : INatsJSFastPublisher
                     throw new NatsJSBatchClosedException();
                 }
 
+                if (_sequence == 0)
+                {
+                    throw new InvalidOperationException("Cannot commit an empty batch; call AddAsync at least once first.");
+                }
+
                 headers = BatchPublishHelper.CloneAndApplyMsgOpts(msg.Headers, opts);
                 _sequence++;
                 seq = _sequence;

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPublisher.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPublisher.cs
@@ -34,11 +34,10 @@ public sealed class NatsJSFastPublisher : INatsJSFastPublisher
     private readonly TimeSpan _ackTimeout;
     private readonly Action<Exception>? _errorHandler;
     private readonly string _ackInboxPrefix;
-    private readonly string _gap;
+    private readonly string _replyPrefix;
 
     private readonly object _lock = new();
 
-    private string _replyPrefix;
     private ushort _flow;
     private long _sequence;
     private long _ackSequence;
@@ -68,13 +67,18 @@ public sealed class NatsJSFastPublisher : INatsJSFastPublisher
         _maxOutstandingAcks = fc.MaxOutstandingAcks > 0 ? fc.MaxOutstandingAcks : DefaultMaxOutstandingAcks;
         _ackTimeout = fc.AckTimeout ?? js.Opts.RequestTimeout;
         _errorHandler = _opts.ErrorHandler;
-        _gap = _opts.ContinueOnGap ? "ok" : "fail";
 
         // Use a non-_INBOX prefix because nats.net dispatches inbox subjects via an exact-match
         // map (with a connection-level _INBOX.<connId>.* wildcard), which would not deliver the
         // multi-token fast-ingest reply subjects.
         _ackInboxPrefix = "_FB." + Nuid.NewNuid();
-        _replyPrefix = BuildReplyPrefix(_ackInboxPrefix, _flow, _gap);
+
+        // The flow and gap tokens in the reply subject are read by the server only when the
+        // batch is first created (on the seq=1 message). They're fixed for the lifetime of the
+        // batch from the server's perspective, even though we may track a different current
+        // ack frequency in _flow as the server adjusts it.
+        var gap = _opts.ContinueOnGap ? "ok" : "fail";
+        _replyPrefix = _ackInboxPrefix + "." + _flow.ToString(CultureInfo.InvariantCulture) + "." + gap + ".";
     }
 
     /// <inheritdoc />
@@ -225,9 +229,6 @@ public sealed class NatsJSFastPublisher : INatsJSFastPublisher
         cts?.Dispose();
     }
 
-    private static string BuildReplyPrefix(string inbox, ushort flow, string gap)
-        => inbox + "." + flow.ToString(CultureInfo.InvariantCulture) + "." + gap + ".";
-
     private string BuildReplySubject(long seq, int operation)
         => _replyPrefix + seq.ToString(CultureInfo.InvariantCulture) + "." + operation.ToString(CultureInfo.InvariantCulture) + ".$FI";
 
@@ -305,10 +306,7 @@ public sealed class NatsJSFastPublisher : INatsJSFastPublisher
             if (isFirst && firstTcs != null)
             {
                 FastPublishFlowAckResponse firstAck;
-                using var cts = cancellationToken.CanBeCanceled
-                    ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
-                    : new CancellationTokenSource();
-                cts.CancelAfter(_ackTimeout);
+                using var cts = BatchPublishHelper.CreateCommitCancellationTokenSource(cancellationToken, _ackTimeout);
 
                 using (cts.Token.Register(static state => ((TaskCompletionSource<FastPublishFlowAckResponse>)state!).TrySetCanceled(), firstTcs))
                 {
@@ -332,10 +330,9 @@ public sealed class NatsJSFastPublisher : INatsJSFastPublisher
                 lock (_lock)
                 {
                     _firstAckTcs = null;
-                    if (firstAck.Messages != 0 && firstAck.Messages != _flow)
+                    if (firstAck.Messages != 0)
                     {
                         _flow = firstAck.Messages;
-                        _replyPrefix = BuildReplyPrefix(_ackInboxPrefix, _flow, _gap);
                     }
 
                     _ackSequence = (long)firstAck.Seq;
@@ -423,10 +420,7 @@ public sealed class NatsJSFastPublisher : INatsJSFastPublisher
                 throw;
             }
 
-            using var cts = cancellationToken.CanBeCanceled
-                ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
-                : new CancellationTokenSource();
-            cts.CancelAfter(_ackTimeout);
+            using var cts = BatchPublishHelper.CreateCommitCancellationTokenSource(cancellationToken, _ackTimeout);
 
             BatchPublishAckResponse commitAck;
             using (cts.Token.Register(static state => ((TaskCompletionSource<BatchPublishAckResponse>)state!).TrySetCanceled(), commitTcs))
@@ -631,15 +625,12 @@ public sealed class NatsJSFastPublisher : INatsJSFastPublisher
                 firstTcs = _firstAckTcs;
                 _firstAckTcs = null;
                 firstTcs.TrySetResult(flow);
-
-                // First ack updates state inside AddMsgInternalAsync continuation.
                 return;
             }
 
-            if (flow.Messages != 0 && flow.Messages != _flow)
+            if (flow.Messages != 0)
             {
                 _flow = flow.Messages;
-                _replyPrefix = BuildReplyPrefix(_ackInboxPrefix, _flow, _gap);
             }
 
             _ackSequence = (long)flow.Seq;
@@ -713,10 +704,7 @@ public sealed class NatsJSFastPublisher : INatsJSFastPublisher
     {
         var pingInterval = TimeSpan.FromMilliseconds(Math.Max(1, _ackTimeout.TotalMilliseconds / 3));
 
-        using var cts = cancellationToken.CanBeCanceled
-            ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
-            : new CancellationTokenSource();
-        cts.CancelAfter(_ackTimeout);
+        using var cts = BatchPublishHelper.CreateCommitCancellationTokenSource(cancellationToken, _ackTimeout);
 
         using (cts.Token.Register(static state => ((TaskCompletionSource<bool>)state!).TrySetCanceled(), stallTcs))
         {

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPublisherOpts.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSFastPublisherOpts.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Synadia.Orbit.JetStream.Publisher;
+
+/// <summary>
+/// Configures a <see cref="NatsJSFastPublisher"/>.
+/// </summary>
+public record NatsJSFastPublisherOpts
+{
+    /// <summary>
+    /// Gets a value indicating whether the server should continue the batch on a detected gap.
+    /// When false (default), the server abandons the batch on a gap. When true, the batch
+    /// continues and the gap is reported via <see cref="ErrorHandler"/>.
+    /// </summary>
+    public bool ContinueOnGap { get; init; }
+
+    /// <summary>
+    /// Gets the handler for asynchronous errors (gap reports, server-side per-message errors,
+    /// and ack-deserialization failures). Called from the ack-processing loop, so it must not
+    /// block.
+    /// </summary>
+    public Action<Exception>? ErrorHandler { get; init; }
+
+    /// <summary>
+    /// Gets the flow control configuration.
+    /// </summary>
+    public NatsJSFastPublishFlowControl? FlowControl { get; init; }
+}

--- a/src/Synadia.Orbit.JetStream.Publisher/PACKAGE.md
+++ b/src/Synadia.Orbit.JetStream.Publisher/PACKAGE.md
@@ -8,6 +8,9 @@ Higher-level publishers for NATS JetStream:
   commit them atomically (all-or-nothing), with optional flow control. Requires NATS
   Server 2.12+ and `AllowAtomicPublish = true` on the stream. See
   [ADR-50](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-50.md).
+- **Fast-ingest publisher** (`NatsJSFastPublisher`) — high-throughput batch publishing
+  without atomicity. Server-driven flow control, optional per-message gap reporting.
+  Requires NATS Server 2.14+ and `AllowBatchPublish = true` on the stream.
 
 ## Backpressure Publisher
 
@@ -152,3 +155,56 @@ or a specific subtype per server error code:
 `NatsJSBatchClosedException` is thrown when using a publisher after commit or discard.
 `NatsJSInvalidBatchAckException` is thrown when the server's batch ack response does not
 match the committed batch.
+
+## Fast-Ingest Batch Publishing
+
+`NatsJSFastPublisher` delivers high-throughput batch publishing without atomicity.
+Individual messages may be lost (gaps) and a partial batch may persist. The server
+drives flow control: `AddAsync` / `AddMsgAsync` stalls when the configured outstanding
+ack window is exceeded. Stream message-count limit per batch is unbounded.
+
+```csharp
+// dotnet add package nats.net
+// dotnet add package Synadia.Orbit.JetStream.Publisher
+await using var client = new NatsClient();
+var js = client.CreateJetStreamContext();
+
+await js.CreateStreamAsync(new StreamConfig("METRICS", ["metrics.>"])
+{
+    AllowBatchPublish = true,
+});
+
+await using var batch = js.CreateOrbitFastPublisher();
+
+for (int i = 0; i < 100_000; i++)
+{
+    await batch.AddAsync($"metrics.{i % 16}", $"value-{i}"u8.ToArray());
+}
+
+NatsJSBatchAck ack = await batch.CloseAsync();
+Console.WriteLine($"Persisted {ack.BatchSize} messages to {ack.Stream}");
+```
+
+Use `CommitAsync` / `CommitMsgAsync` to publish a final message and commit, or
+`CloseAsync` to commit without storing a final message (end-of-batch).
+
+### Flow control and gap handling
+
+```csharp
+await using var batch = js.CreateOrbitFastPublisher(new NatsJSFastPublisherOpts
+{
+    ContinueOnGap = true,                            // server reports gaps but keeps going
+    ErrorHandler = ex => Console.WriteLine(ex),       // gaps and per-message errors
+    FlowControl = new NatsJSFastPublishFlowControl
+    {
+        Flow = 200,
+        MaxOutstandingAcks = 4,
+        AckTimeout = TimeSpan.FromSeconds(5),
+    },
+});
+```
+
+When `ContinueOnGap` is false (default) the server abandons the batch on the first
+gap. When true, gaps surface via `ErrorHandler` as `NatsJSFastPublishGapException`
+and the batch continues. Per-message server errors arrive as
+`NatsJSFastPublishMessageException`.

--- a/tests/Synadia.Orbit.JetStream.Publisher.Test/JetStreamFastPublishTest.cs
+++ b/tests/Synadia.Orbit.JetStream.Publisher.Test/JetStreamFastPublishTest.cs
@@ -155,6 +155,20 @@ public class JetStreamFastPublishTest
     }
 
     [Fact]
+    public async Task Fast_batch_commit_without_add_throws()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectAsync();
+        Assert.SkipUnless(connection.HasMinServerVersion(2, 14), $"Server version {connection.ServerInfo?.Version} does not support fast batch publish (requires 2.14+)");
+
+        var js = connection.CreateJetStreamContext();
+        await using var batch = js.CreateOrbitFastPublisher();
+        var ct = TestContext.Current.CancellationToken;
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await batch.CommitAsync("subject", "data"u8.ToArray(), cancellationToken: ct));
+    }
+
+    [Fact]
     public async Task Fast_batch_continue_on_gap()
     {
         await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });

--- a/tests/Synadia.Orbit.JetStream.Publisher.Test/JetStreamFastPublishTest.cs
+++ b/tests/Synadia.Orbit.JetStream.Publisher.Test/JetStreamFastPublishTest.cs
@@ -1,0 +1,218 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using NATS.Client.Core;
+using NATS.Client.JetStream.Models;
+using NATS.Net;
+using Synadia.Orbit.TestUtils;
+
+namespace Synadia.Orbit.JetStream.Publisher.Test;
+
+[Collection("nats-server")]
+public class JetStreamFastPublishTest
+{
+    private readonly ITestOutputHelper _output;
+    private readonly NatsServerFixture _server;
+
+    public JetStreamFastPublishTest(ITestOutputHelper output, NatsServerFixture server)
+    {
+        _output = output;
+        _server = server;
+    }
+
+    [Fact]
+    public async Task Basic_fast_batch_publishing()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectAsync();
+        Assert.SkipUnless(connection.HasMinServerVersion(2, 14), $"Server version {connection.ServerInfo?.Version} does not support fast batch publish (requires 2.14+)");
+
+        var js = connection.CreateJetStreamContext();
+        var prefix = _server.GetNextId();
+        var streamName = $"{prefix}TEST";
+        var subject = $"{prefix}test";
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var stream = await js.CreateStreamAsync(
+            new StreamConfig(streamName, [$"{subject}.>"]) { AllowBatchPublish = true },
+            ct);
+
+        await using var batch = js.CreateOrbitFastPublisher();
+
+        var ack1 = await batch.AddAsync($"{subject}.1", "message 1"u8.ToArray(), cancellationToken: ct);
+        Assert.Equal(1, ack1.BatchSequence);
+
+        var ack2 = await batch.AddMsgAsync(
+            new NatsMsg<byte[]> { Subject = $"{subject}.2", Data = "message 2"u8.ToArray() },
+            cancellationToken: ct);
+        Assert.Equal(2, ack2.BatchSequence);
+
+        var commitAck = await batch.CommitAsync($"{subject}.3", "message 3"u8.ToArray(), cancellationToken: ct);
+
+        Assert.NotNull(commitAck);
+        Assert.Equal(3, commitAck.BatchSize);
+        Assert.NotEmpty(commitAck.BatchId);
+        Assert.Equal(streamName, commitAck.Stream);
+        Assert.True(batch.IsClosed);
+
+        await Assert.ThrowsAsync<NatsJSBatchClosedException>(
+            async () => await batch.AddAsync($"{subject}.4", "message 4"u8.ToArray(), cancellationToken: ct));
+
+        await stream.RefreshAsync(ct);
+        Assert.Equal(3L, stream.Info.State.Messages);
+    }
+
+    [Fact]
+    public async Task Fast_batch_with_flow_control()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectAsync();
+        Assert.SkipUnless(connection.HasMinServerVersion(2, 14), $"Server version {connection.ServerInfo?.Version} does not support fast batch publish (requires 2.14+)");
+
+        var js = connection.CreateJetStreamContext();
+        var prefix = _server.GetNextId();
+        var streamName = $"{prefix}TEST";
+        var subject = $"{prefix}test";
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var stream = await js.CreateStreamAsync(
+            new StreamConfig(streamName, [$"{subject}.>"]) { AllowBatchPublish = true },
+            ct);
+
+        var opts = new NatsJSFastPublisherOpts
+        {
+            FlowControl = new NatsJSFastPublishFlowControl
+            {
+                Flow = 50,
+                MaxOutstandingAcks = 3,
+                AckTimeout = TimeSpan.FromSeconds(5),
+            },
+        };
+
+        await using var batch = js.CreateOrbitFastPublisher(opts);
+
+        for (int i = 0; i < 200; i++)
+        {
+            await batch.AddAsync($"{subject}.msg", "data"u8.ToArray(), cancellationToken: ct);
+        }
+
+        var commitAck = await batch.CommitAsync($"{subject}.final", "final"u8.ToArray(), cancellationToken: ct);
+
+        Assert.Equal(201, commitAck.BatchSize);
+
+        await stream.RefreshAsync(ct);
+        Assert.Equal(201L, stream.Info.State.Messages);
+    }
+
+    [Fact]
+    public async Task Fast_batch_close_without_final_message()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectAsync();
+        Assert.SkipUnless(connection.HasMinServerVersion(2, 14), $"Server version {connection.ServerInfo?.Version} does not support fast batch publish (requires 2.14+)");
+
+        var js = connection.CreateJetStreamContext();
+        var prefix = _server.GetNextId();
+        var streamName = $"{prefix}TEST";
+        var subject = $"{prefix}test";
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var stream = await js.CreateStreamAsync(
+            new StreamConfig(streamName, [$"{subject}.>"]) { AllowBatchPublish = true },
+            ct);
+
+        await using var batch = js.CreateOrbitFastPublisher();
+
+        await batch.AddAsync($"{subject}.1", "message 1"u8.ToArray(), cancellationToken: ct);
+        await batch.AddAsync($"{subject}.2", "message 2"u8.ToArray(), cancellationToken: ct);
+
+        var commitAck = await batch.CloseAsync(ct);
+
+        Assert.Equal(2, commitAck.BatchSize);
+        Assert.True(batch.IsClosed);
+
+        await Assert.ThrowsAsync<NatsJSBatchClosedException>(
+            async () => await batch.AddAsync($"{subject}.3", "message 3"u8.ToArray(), cancellationToken: ct));
+
+        await stream.RefreshAsync(ct);
+        Assert.Equal(2L, stream.Info.State.Messages);
+    }
+
+    [Fact]
+    public async Task Fast_batch_close_empty_throws()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectAsync();
+        Assert.SkipUnless(connection.HasMinServerVersion(2, 14), $"Server version {connection.ServerInfo?.Version} does not support fast batch publish (requires 2.14+)");
+
+        var js = connection.CreateJetStreamContext();
+        await using var batch = js.CreateOrbitFastPublisher();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await batch.CloseAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Fast_batch_continue_on_gap()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectAsync();
+        Assert.SkipUnless(connection.HasMinServerVersion(2, 14), $"Server version {connection.ServerInfo?.Version} does not support fast batch publish (requires 2.14+)");
+
+        var js = connection.CreateJetStreamContext();
+        var prefix = _server.GetNextId();
+        var streamName = $"{prefix}TEST";
+        var subject = $"{prefix}test";
+
+        var ct = TestContext.Current.CancellationToken;
+
+        await js.CreateStreamAsync(
+            new StreamConfig(streamName, [$"{subject}.>"]) { AllowBatchPublish = true },
+            ct);
+
+        var opts = new NatsJSFastPublisherOpts
+        {
+            ContinueOnGap = true,
+        };
+
+        await using var batch = js.CreateOrbitFastPublisher(opts);
+
+        for (int i = 0; i < 5; i++)
+        {
+            await batch.AddAsync($"{subject}.msg", "data"u8.ToArray(), cancellationToken: ct);
+        }
+
+        var commitAck = await batch.CommitAsync($"{subject}.final", "final"u8.ToArray(), cancellationToken: ct);
+
+        Assert.Equal(6, commitAck.BatchSize);
+    }
+
+    [Fact]
+    public async Task Fast_batch_not_enabled_throws_on_commit()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectAsync();
+        Assert.SkipUnless(connection.HasMinServerVersion(2, 14), $"Server version {connection.ServerInfo?.Version} does not support fast batch publish (requires 2.14+)");
+
+        var js = connection.CreateJetStreamContext();
+        var prefix = _server.GetNextId();
+        var streamName = $"{prefix}TEST";
+        var subject = $"{prefix}test";
+
+        var ct = TestContext.Current.CancellationToken;
+
+        await js.CreateStreamAsync(
+            new StreamConfig(streamName, [$"{subject}.>"]),
+            ct);
+
+        await using var batch = js.CreateOrbitFastPublisher(new NatsJSFastPublisherOpts
+        {
+            FlowControl = new NatsJSFastPublishFlowControl { AckTimeout = TimeSpan.FromSeconds(2) },
+        });
+
+        await Assert.ThrowsAnyAsync<Exception>(
+            async () => await batch.AddAsync($"{subject}.1", "msg"u8.ToArray(), cancellationToken: ct));
+    }
+}

--- a/tools/OrbitPublish/CmdCompare.cs
+++ b/tools/OrbitPublish/CmdCompare.cs
@@ -1,0 +1,216 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+#pragma warning disable
+
+using System.Diagnostics;
+using NATS.Client.JetStream;
+using NATS.Client.JetStream.Models;
+using NATS.Net;
+using Synadia.Orbit.JetStream.Publisher;
+
+namespace OrbitPublish;
+
+public class CmdCompare
+{
+    private const string StreamName = "BENCH";
+    private const string Subject = "bench";
+    private const int NumberOfMessages = 200_000;
+    private const int PayloadSize = 128;
+    private const int Iterations = 3;
+    private const int FastBatchSize = 5_000;
+    private const int ConcurrentBatchSize = 100;
+
+    public static async Task<int> Run()
+    {
+        await using var client = new NatsClient();
+        var js = client.CreateJetStreamContext();
+
+        var streamConfig = new StreamConfig(StreamName, [$"{Subject}", $"{Subject}.>"])
+        {
+            AllowBatchPublish = true,
+        };
+
+        try
+        {
+            await js.CreateStreamAsync(streamConfig);
+        }
+        catch (NatsJSApiException)
+        {
+            await js.UpdateStreamAsync(streamConfig);
+        }
+
+        Console.WriteLine($"Stream '{StreamName}' ready (AllowBatchPublish=true)");
+        Console.WriteLine($"Messages per run: {NumberOfMessages:N0}, payload: {PayloadSize} bytes, iterations: {Iterations}");
+        Console.WriteLine();
+
+        var stream = await js.GetStreamAsync(StreamName);
+        var payload = new byte[PayloadSize];
+
+        var backends = new (string Name, Func<INatsJSContext, byte[], Task<TimeSpan>> Run)[]
+        {
+            ("Serial", RunSerialAsync),
+            ("Concurrent", RunConcurrentAsync),
+            ("Publisher", RunPublisherAsync),
+            ("FastPublisher", RunFastPublisherAsync),
+        };
+
+        var results = new List<(string Name, double[] Throughputs)>();
+
+        foreach (var (name, runner) in backends)
+        {
+            Console.WriteLine($"--- {name} ---");
+            var throughputs = new double[Iterations];
+            for (int i = 0; i < Iterations; i++)
+            {
+                await stream.PurgeAsync(new StreamPurgeRequest { Keep = 0 });
+                var elapsed = await runner(js, payload);
+                var rate = NumberOfMessages / elapsed.TotalSeconds;
+                throughputs[i] = rate;
+                Console.WriteLine($"  run {i + 1}: {elapsed} {rate:N0} msgs/sec");
+            }
+
+            results.Add((name, throughputs));
+            Console.WriteLine();
+        }
+
+        PrintTable(results);
+        return 0;
+    }
+
+    private static async Task<TimeSpan> RunSerialAsync(INatsJSContext js, byte[] payload)
+    {
+        var sw = Stopwatch.StartNew();
+        for (int i = 0; i < NumberOfMessages; i++)
+        {
+            var ack = await js.PublishAsync(Subject, payload);
+            ack.EnsureSuccess();
+        }
+
+        sw.Stop();
+        return sw.Elapsed;
+    }
+
+    private static async Task<TimeSpan> RunConcurrentAsync(INatsJSContext js, byte[] payload)
+    {
+        var futures = new NatsJSPublishConcurrentFuture[ConcurrentBatchSize];
+        var sw = Stopwatch.StartNew();
+        for (int i = 0; i < NumberOfMessages / ConcurrentBatchSize; i++)
+        {
+            for (int j = 0; j < ConcurrentBatchSize; j++)
+            {
+                futures[j] = await js.PublishConcurrentAsync(Subject, payload);
+            }
+
+            foreach (var future in futures)
+            {
+                await using (future)
+                {
+                    var ack = await future.GetResponseAsync();
+                    ack.EnsureSuccess();
+                }
+            }
+        }
+
+        sw.Stop();
+        return sw.Elapsed;
+    }
+
+    private static async Task<TimeSpan> RunPublisherAsync(INatsJSContext js, byte[] payload)
+    {
+        using var cts = new CancellationTokenSource();
+        var publisher = js.Connection.CreateOrbitJetStreamPublisher<byte[]>();
+        await publisher.StartAsync(cts.Token);
+
+        var sub = Task.Run(
+            async () =>
+            {
+                int count = 0;
+                await foreach (var status in publisher.SubscribeAsync(cts.Token))
+                {
+                    count++;
+                    if (count == NumberOfMessages)
+                    {
+                        await cts.CancelAsync();
+                        return;
+                    }
+                }
+            },
+            cts.Token);
+
+        var sw = Stopwatch.StartNew();
+        for (int i = 0; i < NumberOfMessages; i++)
+        {
+            await publisher.PublishAsync(Subject, payload, cancellationToken: CancellationToken.None);
+        }
+
+        try
+        {
+            await sub;
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        sw.Stop();
+        return sw.Elapsed;
+    }
+
+    private static async Task<TimeSpan> RunFastPublisherAsync(INatsJSContext js, byte[] payload)
+    {
+        var sw = Stopwatch.StartNew();
+        int sent = 0;
+        while (sent < NumberOfMessages)
+        {
+            int remaining = NumberOfMessages - sent;
+            int chunk = Math.Min(FastBatchSize, remaining);
+
+            await using var batch = js.CreateOrbitFastPublisher();
+            for (int i = 0; i < chunk - 1; i++)
+            {
+                await batch.AddAsync(Subject, payload);
+            }
+
+            await batch.CommitAsync(Subject, payload);
+            sent += chunk;
+        }
+
+        sw.Stop();
+        return sw.Elapsed;
+    }
+
+    private static void PrintTable(List<(string Name, double[] Throughputs)> results)
+    {
+        Console.WriteLine("=== Comparison (msgs/sec) ===");
+        Console.WriteLine($"{"Backend",-16} {"Min",12} {"Median",12} {"Max",12}  Relative (vs Serial median)");
+
+        double serialMedian = 0;
+        foreach (var (name, t) in results)
+        {
+            if (name == "Serial")
+            {
+                serialMedian = Median(t);
+                break;
+            }
+        }
+
+        foreach (var (name, t) in results)
+        {
+            var sorted = (double[])t.Clone();
+            Array.Sort(sorted);
+            double min = sorted[0];
+            double max = sorted[^1];
+            double median = Median(sorted);
+            string relative = serialMedian > 0 ? $"{median / serialMedian:F2}x" : "n/a";
+            Console.WriteLine($"{name,-16} {min,12:N0} {median,12:N0} {max,12:N0}  {relative}");
+        }
+    }
+
+    private static double Median(double[] values)
+    {
+        var sorted = (double[])values.Clone();
+        Array.Sort(sorted);
+        int n = sorted.Length;
+        return n % 2 == 0 ? (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0 : sorted[n / 2];
+    }
+}


### PR DESCRIPTION
Adds `NatsJSFastPublisher` and the `CreateOrbitFastPublisher` extension on `INatsJSContext` for high-throughput, non-atomic batch publishing per ADR-50. The server drives flow control via the reply subject pattern and emits `ack`/`gap`/`err` typed responses; `AddAsync`/`AddMsgAsync` stall when the configured outstanding ack window is exceeded. `CommitAsync` finalizes with a final message and `CloseAsync` ends the batch (EOB) without storing one.

Requires NATS Server 2.14+ and `AllowBatchPublish = true` on the stream. Bumps NATS .NET dependency to `2.8.0-preview.2` for the new `StreamConfig.AllowBatchPublish` field.