### PR TITLE
Release JetStream.Publisher 1.0.0-preview.6

### DIFF
--- a/src/Synadia.Orbit.JetStream.Publisher/version.txt
+++ b/src/Synadia.Orbit.JetStream.Publisher/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.5
+1.0.0-preview.6


### PR DESCRIPTION
Adds the fast-ingest batch publisher (`NatsJSFastPublisher`) per ADR-50 for high-throughput, non-atomic batch publishing. Requires nats-server v2.14+ and `StreamConfig.AllowBatchPublish = true`.

- Add JetStream fast-ingest batch publisher (#60)
