### PR TITLE
Add end-of-batch sentinel to Batch Publisher

### DIFF
--- a/src/Synadia.Orbit.JetStream.Publisher/INatsJSBatchPublisher.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/INatsJSBatchPublisher.cs
@@ -103,6 +103,20 @@ public interface INatsJSBatchPublisher : IAsyncDisposable
     Task<NatsJSBatchAck> CommitMsgAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Commits the batch with an end-of-batch sentinel; the final message is not stored.
+    /// Throws <see cref="InvalidOperationException"/> if no messages have been added.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task containing the batch acknowledgment. <see cref="NatsJSBatchAck.BatchSize"/> excludes the sentinel.</returns>
+    /// <remarks>
+    /// If a <see cref="TimeoutException"/> or <see cref="OperationCanceledException"/> is thrown
+    /// after the commit request was sent, the batch may or may not have been persisted; the ack
+    /// may simply have been lost. There is no idempotency key for commits, so callers should
+    /// check the stream's last sequence before retrying.
+    /// </remarks>
+    Task<NatsJSBatchAck> CloseAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Cancels the batch without committing.
     /// </summary>
     void Discard();

--- a/src/Synadia.Orbit.JetStream.Publisher/INatsJSBatchPublisher.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/INatsJSBatchPublisher.cs
@@ -10,10 +10,10 @@ namespace Synadia.Orbit.JetStream.Publisher;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Disposing without calling <c>CommitAsync</c> or <c>CommitMsgAsync</c> closes the publisher
-/// locally but leaves any already-sent messages as an incomplete batch on the server until the
-/// server's batch timeout expires. Call <see cref="Discard"/> or commit before disposal to make
-/// the intent explicit.
+/// Disposing without calling <c>CommitAsync</c>, <c>CommitMsgAsync</c>, or <c>CloseAsync</c>
+/// closes the publisher locally but leaves any already-sent messages as an incomplete batch on
+/// the server until the server's batch timeout expires. Call <see cref="Discard"/> or commit
+/// before disposal to make the intent explicit.
 /// </para>
 /// <para>
 /// If a payload's value implements <see cref="IDisposable"/> (for example
@@ -109,6 +109,7 @@ public interface INatsJSBatchPublisher : IAsyncDisposable
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task containing the batch acknowledgment. <see cref="NatsJSBatchAck.BatchSize"/> excludes the sentinel.</returns>
     /// <remarks>
+    /// The sentinel is published on the subject of the first message added to the batch.
     /// If a <see cref="TimeoutException"/> or <see cref="OperationCanceledException"/> is thrown
     /// after the commit request was sent, the batch may or may not have been persisted; the ack
     /// may simply have been lost. There is no idempotency key for commits, so callers should

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchHeaders.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchHeaders.cs
@@ -19,7 +19,8 @@ public static class NatsJSBatchHeaders
     public const string BatchSeq = "Nats-Batch-Sequence";
 
     /// <summary>
-    /// Signals the final message in a batch when set to "1".
+    /// Signals the final message in a batch. Set to "1" to commit and store this message,
+    /// or "eob" to commit without storing it (server 2.14+).
     /// </summary>
     public const string BatchCommit = "Nats-Batch-Commit";
 }

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublisher.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublisher.cs
@@ -24,6 +24,7 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
     private readonly object _lock = new();
     private int _sequence;
     private bool _closed;
+    private string? _batchSubject;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NatsJSBatchPublisher"/> class.
@@ -85,12 +86,35 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
             Subject = subject,
             Data = data,
         };
-        return CommitMsgInternalAsync(msg, opts, serializer, cancellationToken);
+        return CommitMsgInternalAsync(msg, opts, serializer, eob: false, cancellationToken);
     }
 
     /// <inheritdoc />
     public Task<NatsJSBatchAck> CommitMsgAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts = null, INatsSerialize<T>? serializer = null, CancellationToken cancellationToken = default)
-        => CommitMsgInternalAsync(msg, opts, serializer, cancellationToken);
+        => CommitMsgInternalAsync(msg, opts, serializer, eob: false, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<NatsJSBatchAck> CloseAsync(CancellationToken cancellationToken = default)
+    {
+        string subject;
+        lock (_lock)
+        {
+            if (_closed)
+            {
+                throw new NatsJSBatchClosedException();
+            }
+
+            if (_sequence == 0 || _batchSubject == null)
+            {
+                throw new InvalidOperationException("Cannot close an empty batch");
+            }
+
+            subject = _batchSubject;
+        }
+
+        var msg = new NatsMsg<byte[]> { Subject = subject };
+        return CommitMsgInternalAsync<byte[]>(msg, opts: null, serializer: null, eob: true, cancellationToken);
+    }
 
     /// <inheritdoc />
     public void Discard()
@@ -150,6 +174,11 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
 
                 _sequence++;
                 currentSeq = _sequence;
+
+                if (currentSeq == 1)
+                {
+                    _batchSubject = msg.Subject;
+                }
 
                 needsAck = (_flowControl.AckFirst && currentSeq == 1)
                     || (_flowControl.AckEvery > 0 && currentSeq % _flowControl.AckEvery == 0);
@@ -223,7 +252,7 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
         }
     }
 
-    private async Task<NatsJSBatchAck> CommitMsgInternalAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts, INatsSerialize<T>? serializer, CancellationToken cancellationToken)
+    private async Task<NatsJSBatchAck> CommitMsgInternalAsync<T>(NatsMsg<T> msg, NatsJSBatchMsgOpts? opts, INatsSerialize<T>? serializer, bool eob, CancellationToken cancellationToken)
     {
         var owned = msg.Data as IDisposable;
         try
@@ -251,7 +280,7 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
 
             headers[NatsJSBatchHeaders.BatchId] = batchId;
             headers[NatsJSBatchHeaders.BatchSeq] = currentSeq.ToString();
-            headers[NatsJSBatchHeaders.BatchCommit] = "1";
+            headers[NatsJSBatchHeaders.BatchCommit] = eob ? "eob" : "1";
 
             var msgToSend = msg with { Headers = headers };
 
@@ -282,10 +311,11 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
                 BatchPublishHelper.ThrowBatchPublishException(batchResponse.Error);
             }
 
+            var expectedSize = eob ? currentSeq - 1 : currentSeq;
             if (batchResponse == null ||
                 string.IsNullOrEmpty(batchResponse.Stream) ||
                 batchResponse.BatchId != batchId ||
-                batchResponse.BatchSize != currentSeq)
+                batchResponse.BatchSize != expectedSize)
             {
                 throw new NatsJSInvalidBatchAckException();
             }

--- a/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublisher.cs
+++ b/src/Synadia.Orbit.JetStream.Publisher/NatsJSBatchPublisher.cs
@@ -135,7 +135,7 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
     /// uncommitted batch: messages already sent with <c>AddAsync</c> or <c>AddMsgAsync</c>
     /// remain as an incomplete batch on the server until the server's batch timeout expires and
     /// the in-progress messages are garbage collected. To finalize a batch explicitly, call
-    /// <c>CommitAsync</c> or <c>CommitMsgAsync</c> before disposal.
+    /// <c>CommitAsync</c>, <c>CommitMsgAsync</c>, or <c>CloseAsync</c> before disposal.
     /// </summary>
     /// <returns>A completed <see cref="ValueTask"/>.</returns>
     public ValueTask DisposeAsync()
@@ -273,8 +273,19 @@ public sealed class NatsJSBatchPublisher : INatsJSBatchPublisher
 
                 // Close up-front so concurrent commits can't both send.
                 _closed = true;
-                _sequence++;
-                currentSeq = _sequence;
+
+                // EOB: don't bump _sequence. The sentinel still ships with seq n+1 on the wire,
+                // but Size keeps reporting the count of stored messages, matching ack.BatchSize.
+                if (eob)
+                {
+                    currentSeq = _sequence + 1;
+                }
+                else
+                {
+                    _sequence++;
+                    currentSeq = _sequence;
+                }
+
                 batchId = _batchId;
             }
 

--- a/src/Synadia.Orbit.JetStream.Publisher/PACKAGE.md
+++ b/src/Synadia.Orbit.JetStream.Publisher/PACKAGE.md
@@ -91,6 +91,18 @@ NatsJSBatchAck ack = await batch.CommitAsync("orders.3", "third"u8.ToArray());
 Console.WriteLine($"Committed {ack.BatchSize} messages as batch {ack.BatchId} to {ack.Stream}");
 ```
 
+To commit without storing a final message, use `CloseAsync` (NATS Server 2.14+):
+
+```csharp
+await using var batch = new NatsJSBatchPublisher(js);
+
+await batch.AddAsync("orders.1", "first"u8.ToArray());
+await batch.AddAsync("orders.2", "second"u8.ToArray());
+
+NatsJSBatchAck ack = await batch.CloseAsync();
+// ack.BatchSize == 2 (the EOB sentinel is not stored).
+```
+
 For a one-shot batch of messages already in memory, use the `PublishMsgBatchAsync`
 extension on `INatsJSContext`:
 

--- a/tests/Synadia.Orbit.JetStream.Publisher.Test/JetStreamBatchPublishTest.cs
+++ b/tests/Synadia.Orbit.JetStream.Publisher.Test/JetStreamBatchPublishTest.cs
@@ -590,6 +590,39 @@ public class JetStreamBatchPublishTest
     }
 
     [Fact]
+    public async Task Close_size_matches_ack_batch_size()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectAsync();
+        Assert.SkipUnless(connection.HasMinServerVersion(2, 14), $"Server version {connection.ServerInfo?.Version} does not support batch commit EOB (requires 2.14+)");
+
+        var js = connection.CreateJetStreamContext();
+        var prefix = _server.GetNextId();
+        var streamName = $"{prefix}TEST";
+        var subject = $"{prefix}test";
+
+        var ct = TestContext.Current.CancellationToken;
+
+        await js.CreateStreamAsync(
+            new StreamConfig(streamName, [$"{subject}.>"]) { AllowAtomicPublish = true },
+            ct);
+
+        await using var batch = new NatsJSBatchPublisher(js);
+
+        await batch.AddAsync($"{subject}.1", "message 1"u8.ToArray(), cancellationToken: ct);
+        await batch.AddAsync($"{subject}.2", "message 2"u8.ToArray(), cancellationToken: ct);
+        await batch.AddAsync($"{subject}.3", "message 3"u8.ToArray(), cancellationToken: ct);
+
+        Assert.Equal(3, batch.Size);
+
+        var ack = await batch.CloseAsync(ct);
+
+        // Size must not include the EOB sentinel; it should match ack.BatchSize.
+        Assert.Equal(3, ack.BatchSize);
+        Assert.Equal(ack.BatchSize, batch.Size);
+    }
+
+    [Fact]
     public async Task Close_empty_batch_throws()
     {
         await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });

--- a/tests/Synadia.Orbit.JetStream.Publisher.Test/JetStreamBatchPublishTest.cs
+++ b/tests/Synadia.Orbit.JetStream.Publisher.Test/JetStreamBatchPublishTest.cs
@@ -551,4 +551,122 @@ public class JetStreamBatchPublishTest
         Assert.NotNull(ack);
         Assert.Equal(26, ack.BatchSize);
     }
+
+    [Fact]
+    public async Task Close_with_eob_sentinel()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectAsync();
+        Assert.SkipUnless(connection.HasMinServerVersion(2, 14), $"Server version {connection.ServerInfo?.Version} does not support batch commit EOB (requires 2.14+)");
+
+        var js = connection.CreateJetStreamContext();
+        var prefix = _server.GetNextId();
+        var streamName = $"{prefix}TEST";
+        var subject = $"{prefix}test";
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var stream = await js.CreateStreamAsync(
+            new StreamConfig(streamName, [$"{subject}.>"]) { AllowAtomicPublish = true },
+            ct);
+
+        await using var batch = new NatsJSBatchPublisher(js);
+
+        await batch.AddAsync($"{subject}.1", "message 1"u8.ToArray(), cancellationToken: ct);
+        await batch.AddAsync($"{subject}.2", "message 2"u8.ToArray(), cancellationToken: ct);
+
+        var ack = await batch.CloseAsync(ct);
+
+        Assert.NotNull(ack);
+
+        // EOB sentinel is not stored, so BatchSize counts only the two added messages.
+        Assert.Equal(2, ack.BatchSize);
+        Assert.NotEmpty(ack.BatchId);
+        Assert.Equal(streamName, ack.Stream);
+        Assert.True(batch.IsClosed);
+
+        await stream.RefreshAsync(ct);
+        Assert.Equal(2L, stream.Info.State.Messages);
+    }
+
+    [Fact]
+    public async Task Close_empty_batch_throws()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectAsync();
+        Assert.SkipUnless(connection.HasMinServerVersion(2, 14), $"Server version {connection.ServerInfo?.Version} does not support batch commit EOB (requires 2.14+)");
+
+        var js = connection.CreateJetStreamContext();
+        var prefix = _server.GetNextId();
+        var streamName = $"{prefix}TEST";
+        var subject = $"{prefix}test";
+
+        var ct = TestContext.Current.CancellationToken;
+
+        await js.CreateStreamAsync(
+            new StreamConfig(streamName, [$"{subject}.>"]) { AllowAtomicPublish = true },
+            ct);
+
+        await using var batch = new NatsJSBatchPublisher(js);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await batch.CloseAsync(ct));
+
+        // Empty close does not close the batch; subsequent Add still works.
+        Assert.False(batch.IsClosed);
+        await batch.AddAsync($"{subject}.1", "message 1"u8.ToArray(), cancellationToken: ct);
+        var ack = await batch.CloseAsync(ct);
+        Assert.Equal(1, ack.BatchSize);
+    }
+
+    [Fact]
+    public async Task Close_after_close_throws()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectAsync();
+        Assert.SkipUnless(connection.HasMinServerVersion(2, 14), $"Server version {connection.ServerInfo?.Version} does not support batch commit EOB (requires 2.14+)");
+
+        var js = connection.CreateJetStreamContext();
+        var prefix = _server.GetNextId();
+        var streamName = $"{prefix}TEST";
+        var subject = $"{prefix}test";
+
+        var ct = TestContext.Current.CancellationToken;
+
+        await js.CreateStreamAsync(
+            new StreamConfig(streamName, [$"{subject}.>"]) { AllowAtomicPublish = true },
+            ct);
+
+        await using var batch = new NatsJSBatchPublisher(js);
+
+        await batch.AddAsync($"{subject}.1", "message 1"u8.ToArray(), cancellationToken: ct);
+        await batch.CloseAsync(ct);
+
+        await Assert.ThrowsAsync<NatsJSBatchClosedException>(async () => await batch.CloseAsync(ct));
+    }
+
+    [Fact]
+    public async Task Close_after_commit_throws()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectAsync();
+        Assert.SkipUnless(connection.HasMinServerVersion(2, 14), $"Server version {connection.ServerInfo?.Version} does not support batch commit EOB (requires 2.14+)");
+
+        var js = connection.CreateJetStreamContext();
+        var prefix = _server.GetNextId();
+        var streamName = $"{prefix}TEST";
+        var subject = $"{prefix}test";
+
+        var ct = TestContext.Current.CancellationToken;
+
+        await js.CreateStreamAsync(
+            new StreamConfig(streamName, [$"{subject}.>"]) { AllowAtomicPublish = true },
+            ct);
+
+        await using var batch = new NatsJSBatchPublisher(js);
+
+        await batch.AddAsync($"{subject}.1", "message 1"u8.ToArray(), cancellationToken: ct);
+        await batch.CommitAsync($"{subject}.2", "message 2"u8.ToArray(), cancellationToken: ct);
+
+        await Assert.ThrowsAsync<NatsJSBatchClosedException>(async () => await batch.CloseAsync(ct));
+    }
 }

--- a/tests/Synadia.Orbit.JetStream.Publisher.Test/JetStreamBatchPublishTest.cs
+++ b/tests/Synadia.Orbit.JetStream.Publisher.Test/JetStreamBatchPublishTest.cs
@@ -617,7 +617,6 @@ public class JetStreamBatchPublishTest
 
         var ack = await batch.CloseAsync(ct);
 
-        // Size must not include the EOB sentinel; it should match ack.BatchSize.
         Assert.Equal(3, ack.BatchSize);
         Assert.Equal(ack.BatchSize, batch.Size);
     }


### PR DESCRIPTION
Adds `CloseAsync` to `NatsJSBatchPublisher` so an atomic batch can be committed without storing a trailing message, using the EOB sentinel from ADR-50 (`Nats-Batch-Commit: eob`, NATS Server 2.14+). The server rewrites the previous message's commit header to `1`, so the last `AddAsync` becomes the stored boundary and the sentinel itself is not persisted; `BatchSize` on the ack excludes it. Existing `CommitAsync` / `CommitMsgAsync` paths are unchanged.