### PR TITLE
Release JetStream.Publisher 1.0.0-preview.7

### DIFF
--- a/src/Synadia.Orbit.JetStream.Publisher/version.txt
+++ b/src/Synadia.Orbit.JetStream.Publisher/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.6
+1.0.0-preview.7


### PR DESCRIPTION
Preview release of JetStream.Publisher adding end-of-batch sentinel support to `NatsJSBatchPublisher`. Requires NATS Server 2.14+ for the new `CloseAsync` path.

- Add end-of-batch sentinel to Batch Publisher (#62)