### PR TITLE
Bump nats-server test matrix to v2.11/v2.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        branch: ['v2.10', 'v2.11', 'latest', 'main']
+        branch: ['v2.11', 'v2.12', 'latest', 'main']
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Drop v2.10 and add v2.12 from the test matrix. v2.14 is the latest server release, so v2.10 is two majors behind; v2.12 covers the version that introduces atomic batch publish used by JetStream.Publisher.