### PR TITLE
Support drain-on-dispose for PCGroups consumers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <NatsVersion>2.8.0-preview.2</NatsVersion>
+    <NatsVersion>2.8.0</NatsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="NATS.Net" Version="$(NatsVersion)" />

--- a/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticConsumeContext.cs
+++ b/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticConsumeContext.cs
@@ -223,6 +223,11 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
 
                     if (!hasNext)
                     {
+                        if (_js.Connection.Opts.DrainSubscriptionsOnDispose)
+                        {
+                            yield break;
+                        }
+
                         break;
                     }
 

--- a/src/Synadia.Orbit.PCGroups/PACKAGE.md
+++ b/src/Synadia.Orbit.PCGroups/PACKAGE.md
@@ -142,6 +142,24 @@ record Event(string EventId, string UserId, string Type);
 | Stream Setup | Requires SubjectTransform | Auto-creates work-queue stream |
 | Configuration | Simpler | More flexible |
 
+## Graceful Shutdown
+
+PCGroups supports NATS .NET drain-on-dispose. Enable it on the connection to let
+in-flight JetStream consumer messages already buffered by the client continue to
+flow through the PCGroups async enumerable before the connection is closed:
+
+```csharp
+await using var nats = new NatsConnection(new NatsOpts
+{
+    DrainSubscriptionsOnDispose = true,
+    ConsumerDrainOnDisposeTimeout = TimeSpan.FromSeconds(30),
+});
+```
+
+Without `DrainSubscriptionsOnDispose`, NATS .NET closes the socket first during
+connection disposal and buffered consumer messages may remain pending until
+`AckWait` expires.
+
 ## Custom Partition Mappings
 
 For fine-grained control over partition distribution:

--- a/src/Synadia.Orbit.PCGroups/Static/NatsPcgStaticConsumeContext.cs
+++ b/src/Synadia.Orbit.PCGroups/Static/NatsPcgStaticConsumeContext.cs
@@ -178,6 +178,11 @@ internal sealed class NatsPcgStaticConsumeContext<T> : IAsyncEnumerable<NatsPcgM
 
                     if (!hasNext)
                     {
+                        if (_js.Connection.Opts.DrainSubscriptionsOnDispose)
+                        {
+                            yield break;
+                        }
+
                         break;
                     }
 

--- a/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
@@ -690,8 +690,8 @@ public class NatsPcgElasticExtensionsTests
     [Fact]
     public async Task ConsumeElastic_ConnectionDisposeDrainsBufferedMessagesAndCompletes()
     {
-        const int totalMsgs = 100;
-        const int bailAt = 10;
+        const int totalMsgs = 30;
+        const int bailAt = 5;
 
         await using var setup = new NatsConnection(new NatsOpts { Url = _server.Url });
         var setupJs = setup.CreateJetStreamContext();
@@ -724,6 +724,7 @@ public class NatsPcgElasticExtensionsTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var consumed = 0;
         var reachedBail = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseAfterDisposeStarts = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var nats = new NatsConnection(new NatsOpts
         {
@@ -747,9 +748,8 @@ public class NatsPcgElasticExtensionsTests
                         if (Volatile.Read(ref consumed) == bailAt)
                         {
                             reachedBail.TrySetResult(true);
+                            await releaseAfterDisposeStarts.Task.ConfigureAwait(false);
                         }
-
-                        await Task.Delay(50, cts.Token);
                     }
                 }
                 catch (OperationCanceledException) when (cts.IsCancellationRequested)
@@ -763,6 +763,7 @@ public class NatsPcgElasticExtensionsTests
             await TaskTestHelpers.AssertCompletesWithinAsync(reachedBail.Task, TimeSpan.FromSeconds(10));
 
             disposeTask = nats.DisposeAsync().AsTask();
+            releaseAfterDisposeStarts.TrySetResult(true);
             await TaskTestHelpers.AssertCompletesWithinAsync(disposeTask, TimeSpan.FromSeconds(10));
 
             await TaskTestHelpers.AssertCompletesWithinAsync(consumeTask, TimeSpan.FromSeconds(10));
@@ -776,6 +777,7 @@ public class NatsPcgElasticExtensionsTests
         }
         finally
         {
+            releaseAfterDisposeStarts.TrySetResult(true);
             cts.Cancel();
             disposeTask ??= nats.DisposeAsync().AsTask();
             await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromSeconds(5)));

--- a/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
@@ -6,6 +6,7 @@ using NATS.Client.Core;
 using NATS.Client.JetStream.Models;
 using NATS.Net;
 using Synadia.Orbit.PCGroups.Elastic;
+using Synadia.Orbit.PCGroups.Test;
 using Synadia.Orbit.TestUtils;
 
 namespace Synadia.Orbit.PCGroups.Test.Elastic;
@@ -683,6 +684,99 @@ public class NatsPcgElasticExtensionsTests
         finally
         {
             await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    [Fact]
+    public async Task ConsumeElastic_ConnectionDisposeDrainsBufferedMessagesAndCompletes()
+    {
+        const int totalMsgs = 100;
+        const int bailAt = 10;
+
+        await using var setup = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var setupJs = setup.CreateJetStreamContext();
+
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
+        var subject = $"{id}.orders.*";
+        var groupName = $"test-group-{id}";
+        var workQueueStreamName = $"{streamName}-{groupName}";
+
+        await setupJs.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = [subject],
+        });
+
+        await setupJs.CreatePcgElasticAsync(
+            streamName,
+            groupName,
+            maxNumMembers: 1,
+            partitioningFilters: [new NatsPcgPartitioningFilter(subject, [1])]);
+
+        await setupJs.AddPcgElasticMembersAsync(streamName, groupName, ["worker"]);
+
+        for (var i = 0; i < totalMsgs; i++)
+        {
+            await setupJs.PublishAsync($"{id}.orders.{i}", $"payload-{i}");
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var consumed = 0;
+        var reachedBail = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var nats = new NatsConnection(new NatsOpts
+        {
+            Url = _server.Url,
+            DrainSubscriptionsOnDispose = true,
+            ConsumerDrainOnDisposeTimeout = TimeSpan.FromSeconds(30),
+        });
+        var js = nats.CreateJetStreamContext();
+
+        var consumeTask = Task.Run(
+            async () =>
+            {
+                try
+                {
+                    await foreach (var msg in js.ConsumePcgElasticAsync<string>(streamName, groupName, "worker", cancellationToken: cts.Token))
+                    {
+                        Interlocked.Increment(ref consumed);
+                        await msg.AckAsync(cancellationToken: cts.Token);
+
+                        if (Volatile.Read(ref consumed) == bailAt)
+                        {
+                            reachedBail.TrySetResult();
+                        }
+
+                        await Task.Delay(50, cts.Token);
+                    }
+                }
+                catch (OperationCanceledException) when (cts.IsCancellationRequested)
+                {
+                }
+            },
+            cts.Token);
+
+        try
+        {
+            await TaskTestHelpers.AssertCompletesWithinAsync(reachedBail.Task, TimeSpan.FromSeconds(10));
+
+            var disposeTask = nats.DisposeAsync().AsTask();
+            await TaskTestHelpers.AssertCompletesWithinAsync(disposeTask, TimeSpan.FromSeconds(10));
+
+            await TaskTestHelpers.AssertCompletesWithinAsync(consumeTask, TimeSpan.FromSeconds(10));
+
+            Assert.True(Volatile.Read(ref consumed) > bailAt, $"consumed {Volatile.Read(ref consumed)} should be greater than {bailAt}");
+
+            await using var check = new NatsConnection(new NatsOpts { Url = _server.Url });
+            var checkJs = check.CreateJetStreamContext();
+            var consumer = await checkJs.GetConsumerAsync(workQueueStreamName, "worker");
+            Assert.Equal(0, consumer.Info.NumAckPending);
+        }
+        finally
+        {
+            cts.Cancel();
+            await Task.WhenAny(consumeTask, Task.Delay(TimeSpan.FromSeconds(5)));
         }
     }
 

--- a/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
@@ -733,6 +733,7 @@ public class NatsPcgElasticExtensionsTests
         });
         var js = nats.CreateJetStreamContext();
 
+        Task? disposeTask = null;
         var consumeTask = Task.Run(
             async () =>
             {
@@ -761,7 +762,7 @@ public class NatsPcgElasticExtensionsTests
         {
             await TaskTestHelpers.AssertCompletesWithinAsync(reachedBail.Task, TimeSpan.FromSeconds(10));
 
-            var disposeTask = nats.DisposeAsync().AsTask();
+            disposeTask = nats.DisposeAsync().AsTask();
             await TaskTestHelpers.AssertCompletesWithinAsync(disposeTask, TimeSpan.FromSeconds(10));
 
             await TaskTestHelpers.AssertCompletesWithinAsync(consumeTask, TimeSpan.FromSeconds(10));
@@ -776,6 +777,8 @@ public class NatsPcgElasticExtensionsTests
         finally
         {
             cts.Cancel();
+            disposeTask ??= nats.DisposeAsync().AsTask();
+            await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromSeconds(5)));
             await Task.WhenAny(consumeTask, Task.Delay(TimeSpan.FromSeconds(5)));
         }
     }

--- a/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
@@ -723,7 +723,7 @@ public class NatsPcgElasticExtensionsTests
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var consumed = 0;
-        var reachedBail = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reachedBail = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var nats = new NatsConnection(new NatsOpts
         {
@@ -746,7 +746,7 @@ public class NatsPcgElasticExtensionsTests
 
                         if (Volatile.Read(ref consumed) == bailAt)
                         {
-                            reachedBail.TrySetResult();
+                            reachedBail.TrySetResult(true);
                         }
 
                         await Task.Delay(50, cts.Token);

--- a/tests/Synadia.Orbit.PCGroups.Test/Static/NatsPcgStaticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Static/NatsPcgStaticExtensionsTests.cs
@@ -585,6 +585,7 @@ public class NatsPcgStaticExtensionsTests
         });
         var js = nats.CreateJetStreamContext();
 
+        Task? disposeTask = null;
         var consumeTask = Task.Run(
             async () =>
             {
@@ -613,7 +614,7 @@ public class NatsPcgStaticExtensionsTests
         {
             await TaskTestHelpers.AssertCompletesWithinAsync(reachedBail.Task, TimeSpan.FromSeconds(10));
 
-            var disposeTask = nats.DisposeAsync().AsTask();
+            disposeTask = nats.DisposeAsync().AsTask();
             await TaskTestHelpers.AssertCompletesWithinAsync(disposeTask, TimeSpan.FromSeconds(10));
 
             await TaskTestHelpers.AssertCompletesWithinAsync(consumeTask, TimeSpan.FromSeconds(10));
@@ -628,6 +629,8 @@ public class NatsPcgStaticExtensionsTests
         finally
         {
             cts.Cancel();
+            disposeTask ??= nats.DisposeAsync().AsTask();
+            await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromSeconds(5)));
             await Task.WhenAny(consumeTask, Task.Delay(TimeSpan.FromSeconds(5)));
         }
     }

--- a/tests/Synadia.Orbit.PCGroups.Test/Static/NatsPcgStaticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Static/NatsPcgStaticExtensionsTests.cs
@@ -575,7 +575,7 @@ public class NatsPcgStaticExtensionsTests
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var consumed = 0;
-        var reachedBail = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reachedBail = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var nats = new NatsConnection(new NatsOpts
         {
@@ -598,7 +598,7 @@ public class NatsPcgStaticExtensionsTests
 
                         if (Volatile.Read(ref consumed) == bailAt)
                         {
-                            reachedBail.TrySetResult();
+                            reachedBail.TrySetResult(true);
                         }
 
                         await Task.Delay(50, cts.Token);

--- a/tests/Synadia.Orbit.PCGroups.Test/Static/NatsPcgStaticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Static/NatsPcgStaticExtensionsTests.cs
@@ -539,8 +539,8 @@ public class NatsPcgStaticExtensionsTests
     [Fact]
     public async Task ConsumeStatic_ConnectionDisposeDrainsBufferedMessagesAndCompletes()
     {
-        const int totalMsgs = 100;
-        const int bailAt = 10;
+        const int totalMsgs = 30;
+        const int bailAt = 5;
 
         await using var setup = new NatsConnection(new NatsOpts { Url = _server.Url });
         var setupJs = setup.CreateJetStreamContext();
@@ -576,6 +576,7 @@ public class NatsPcgStaticExtensionsTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var consumed = 0;
         var reachedBail = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseAfterDisposeStarts = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var nats = new NatsConnection(new NatsOpts
         {
@@ -599,9 +600,8 @@ public class NatsPcgStaticExtensionsTests
                         if (Volatile.Read(ref consumed) == bailAt)
                         {
                             reachedBail.TrySetResult(true);
+                            await releaseAfterDisposeStarts.Task.ConfigureAwait(false);
                         }
-
-                        await Task.Delay(50, cts.Token);
                     }
                 }
                 catch (OperationCanceledException) when (cts.IsCancellationRequested)
@@ -615,6 +615,7 @@ public class NatsPcgStaticExtensionsTests
             await TaskTestHelpers.AssertCompletesWithinAsync(reachedBail.Task, TimeSpan.FromSeconds(10));
 
             disposeTask = nats.DisposeAsync().AsTask();
+            releaseAfterDisposeStarts.TrySetResult(true);
             await TaskTestHelpers.AssertCompletesWithinAsync(disposeTask, TimeSpan.FromSeconds(10));
 
             await TaskTestHelpers.AssertCompletesWithinAsync(consumeTask, TimeSpan.FromSeconds(10));
@@ -628,6 +629,7 @@ public class NatsPcgStaticExtensionsTests
         }
         finally
         {
+            releaseAfterDisposeStarts.TrySetResult(true);
             cts.Cancel();
             disposeTask ??= nats.DisposeAsync().AsTask();
             await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromSeconds(5)));

--- a/tests/Synadia.Orbit.PCGroups.Test/Static/NatsPcgStaticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Static/NatsPcgStaticExtensionsTests.cs
@@ -6,6 +6,7 @@ using NATS.Client.Core;
 using NATS.Client.JetStream.Models;
 using NATS.Net;
 using Synadia.Orbit.PCGroups.Static;
+using Synadia.Orbit.PCGroups.Test;
 using Synadia.Orbit.TestUtils;
 
 namespace Synadia.Orbit.PCGroups.Test.Static;
@@ -532,6 +533,102 @@ public class NatsPcgStaticExtensionsTests
         finally
         {
             await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    [Fact]
+    public async Task ConsumeStatic_ConnectionDisposeDrainsBufferedMessagesAndCompletes()
+    {
+        const int totalMsgs = 100;
+        const int bailAt = 10;
+
+        await using var setup = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var setupJs = setup.CreateJetStreamContext();
+
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
+        var subject = $"{id}.orders.*";
+        var groupName = $"test-group-{id}";
+
+        await setupJs.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = [subject],
+            SubjectTransform = new SubjectTransform
+            {
+                Src = subject,
+                Dest = $"{{{{partition(1,1)}}}}.{id}.orders.{{{{wildcard(1)}}}}",
+            },
+        });
+
+        await setupJs.CreatePcgStaticAsync(
+            streamName,
+            groupName,
+            maxNumMembers: 1,
+            filters: [subject],
+            members: ["worker"]);
+
+        for (var i = 0; i < totalMsgs; i++)
+        {
+            await setupJs.PublishAsync($"{id}.orders.{i}", $"payload-{i}");
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var consumed = 0;
+        var reachedBail = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var nats = new NatsConnection(new NatsOpts
+        {
+            Url = _server.Url,
+            DrainSubscriptionsOnDispose = true,
+            ConsumerDrainOnDisposeTimeout = TimeSpan.FromSeconds(30),
+        });
+        var js = nats.CreateJetStreamContext();
+
+        var consumeTask = Task.Run(
+            async () =>
+            {
+                try
+                {
+                    await foreach (var msg in js.ConsumePcgStaticAsync<string>(streamName, groupName, "worker", cancellationToken: cts.Token))
+                    {
+                        Interlocked.Increment(ref consumed);
+                        await msg.AckAsync(cancellationToken: cts.Token);
+
+                        if (Volatile.Read(ref consumed) == bailAt)
+                        {
+                            reachedBail.TrySetResult();
+                        }
+
+                        await Task.Delay(50, cts.Token);
+                    }
+                }
+                catch (OperationCanceledException) when (cts.IsCancellationRequested)
+                {
+                }
+            },
+            cts.Token);
+
+        try
+        {
+            await TaskTestHelpers.AssertCompletesWithinAsync(reachedBail.Task, TimeSpan.FromSeconds(10));
+
+            var disposeTask = nats.DisposeAsync().AsTask();
+            await TaskTestHelpers.AssertCompletesWithinAsync(disposeTask, TimeSpan.FromSeconds(10));
+
+            await TaskTestHelpers.AssertCompletesWithinAsync(consumeTask, TimeSpan.FromSeconds(10));
+
+            Assert.True(Volatile.Read(ref consumed) > bailAt, $"consumed {Volatile.Read(ref consumed)} should be greater than {bailAt}");
+
+            await using var check = new NatsConnection(new NatsOpts { Url = _server.Url });
+            var checkJs = check.CreateJetStreamContext();
+            var consumer = await checkJs.GetConsumerAsync(streamName, $"{groupName}-worker");
+            Assert.Equal(0, consumer.Info.NumAckPending);
+        }
+        finally
+        {
+            cts.Cancel();
+            await Task.WhenAny(consumeTask, Task.Delay(TimeSpan.FromSeconds(5)));
         }
     }
 }

--- a/tests/Synadia.Orbit.PCGroups.Test/TaskTestHelpers.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/TaskTestHelpers.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Synadia.Orbit.PCGroups.Test;
+
+internal static class TaskTestHelpers
+{
+    public static async Task AssertCompletesWithinAsync(Task task, TimeSpan timeout)
+    {
+        var completed = await Task.WhenAny(task, Task.Delay(timeout)).ConfigureAwait(false);
+        Assert.True(ReferenceEquals(task, completed), $"Task did not complete within {timeout}.");
+        await task.ConfigureAwait(false);
+    }
+
+    public static async Task<T> AssertCompletesWithinAsync<T>(Task<T> task, TimeSpan timeout)
+    {
+        var completed = await Task.WhenAny(task, Task.Delay(timeout)).ConfigureAwait(false);
+        Assert.True(ReferenceEquals(task, completed), $"Task did not complete within {timeout}.");
+        return await task.ConfigureAwait(false);
+    }
+}

--- a/tests/Synadia.Orbit.PCGroups.Test/TaskTestHelpers.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/TaskTestHelpers.cs
@@ -9,13 +9,6 @@ internal static class TaskTestHelpers
     {
         var completed = await Task.WhenAny(task, Task.Delay(timeout)).ConfigureAwait(false);
         Assert.True(ReferenceEquals(task, completed), $"Task did not complete within {timeout}.");
-        await task.ConfigureAwait(false);
-    }
-
-    public static async Task<T> AssertCompletesWithinAsync<T>(Task<T> task, TimeSpan timeout)
-    {
-        var completed = await Task.WhenAny(task, Task.Delay(timeout)).ConfigureAwait(false);
-        Assert.True(ReferenceEquals(task, completed), $"Task did not complete within {timeout}.");
-        return await task.ConfigureAwait(false);
+        await Task.WhenAll(task).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
Attempt to fix #65 

Upgrade NATS.Net to 2.8.0 and let static and elastic PCGroups consume loops complete when the underlying JetStream consumer finishes during drain-on-dispose.

Add regression coverage for buffered-message drain behavior on connection disposal and document the graceful shutdown option.