### PR TITLE
Release PCGroups 1.0.0-preview.7

### DIFF
--- a/src/Synadia.Orbit.PCGroups/version.txt
+++ b/src/Synadia.Orbit.PCGroups/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.6
+1.0.0-preview.7


### PR DESCRIPTION
Releases the PCGroups package with drain-on-dispose support for consumers.

- Support drain-on-dispose for PCGroups consumers (#66)