### PR TITLE
Add drain-on-cancel option to PCGroups consumers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <NatsVersion>2.8.0</NatsVersion>
+    <NatsVersion>3.0.0-preview.9</NatsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="NATS.Net" Version="$(NatsVersion)" />
@@ -15,7 +15,7 @@
 
     <PackageVersion Include="System.Text.Json" Version="8.0.5"/>
     <PackageVersion Include="System.Threading.Channels" Version="8.0.0"/>
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1"/>
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.1"/>
     <PackageVersion Include="PolySharp" Version="1.14.1"/>
 
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="9.0.14"/>

--- a/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticConsumeContext.cs
+++ b/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticConsumeContext.cs
@@ -245,8 +245,10 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
                         yield break;
                     }
 
-                    // Check if we need to stop and recreate
-                    if (_needsRecreate)
+                    // Check if we need to stop and recreate. Skip while actively
+                    // draining on cancel so the buffered messages finish first
+                    // instead of being cut off by a mid-drain membership change.
+                    if (_needsRecreate && !(_drainOnCancel && linkedToken.IsCancellationRequested))
                     {
                         break;
                     }

--- a/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticConsumeContext.cs
+++ b/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticConsumeContext.cs
@@ -22,6 +22,7 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
     private readonly string _memberName;
     private readonly INatsDeserialize<T>? _serializer;
     private readonly ConsumerConfig? _userConfig;
+    private readonly bool _drainOnCancel;
 
     private readonly CancellationTokenSource _cts = new();
     private readonly object _configLock = new();
@@ -40,7 +41,8 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
         string memberName,
         NatsPcgElasticConfig config,
         INatsDeserialize<T>? serializer,
-        ConsumerConfig? userConfig)
+        ConsumerConfig? userConfig,
+        bool drainOnCancel)
     {
         _js = js;
         _streamName = streamName;
@@ -49,6 +51,7 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
         _config = config;
         _serializer = serializer;
         _userConfig = userConfig;
+        _drainOnCancel = drainOnCancel;
     }
 
     public async ValueTask DisposeAsync()
@@ -175,6 +178,7 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
                     Expires = NatsPcgConstants.PullTimeout,
                     IdleHeartbeat = TimeSpan.FromMilliseconds(NatsPcgConstants.PullTimeout.TotalMilliseconds / 2),
                     PriorityGroup = priorityGroup,
+                    DrainOnCancel = _drainOnCancel,
                 };
 
                 messages = _consumer.ConsumeAsync(_serializer, consumeOpts, linkedToken);
@@ -223,7 +227,10 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
 
                     if (!hasNext)
                     {
-                        if (_js.Connection.Opts.DrainSubscriptionsOnDispose)
+                        // Underlying consume completed. When cancelled with DrainOnCancel,
+                        // the client has already flushed buffered messages, so finish here
+                        // instead of looping back to recreate the consumer.
+                        if (linkedToken.IsCancellationRequested || _js.Connection.Opts.DrainSubscriptionsOnDispose)
                         {
                             yield break;
                         }
@@ -231,7 +238,9 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
                         break;
                     }
 
-                    if (_stopped || linkedToken.IsCancellationRequested)
+                    // While draining on cancel keep yielding the buffered messages the
+                    // client hands us; the loop ends when MoveNextAsync reports completion.
+                    if (!_drainOnCancel && (_stopped || linkedToken.IsCancellationRequested))
                     {
                         yield break;
                     }

--- a/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticExtensions.cs
+++ b/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticExtensions.cs
@@ -102,7 +102,7 @@ public static class NatsPcgElasticExtensions
     /// <param name="memberName">Name of this member.</param>
     /// <param name="serializer">Optional deserializer for message data.</param>
     /// <param name="config">Optional consumer configuration overrides.</param>
-    /// <param name="drainOnCancel">When true, cancelling <paramref name="cancellationToken"/> drains the consumer gracefully (stop pulling, deliver buffered messages so handlers can ACK on the still-open connection) before the enumerable completes, instead of stopping immediately.</param>
+    /// <param name="drainOnCancel">When true, a graceful stop (cancelling <paramref name="cancellationToken"/>, or an internal lifecycle event such as a membership change) drains the consumer (stop pulling, deliver buffered messages so handlers can ACK on the still-open connection) before the enumerable completes, instead of stopping immediately.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>An async enumerable of messages from the consumer group.</returns>
     public static async IAsyncEnumerable<INatsJSMsg<T>> ConsumePcgElasticAsync<T>(

--- a/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticExtensions.cs
+++ b/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticExtensions.cs
@@ -102,6 +102,7 @@ public static class NatsPcgElasticExtensions
     /// <param name="memberName">Name of this member.</param>
     /// <param name="serializer">Optional deserializer for message data.</param>
     /// <param name="config">Optional consumer configuration overrides.</param>
+    /// <param name="drainOnCancel">When true, cancelling <paramref name="cancellationToken"/> drains the consumer gracefully (stop pulling, deliver buffered messages so handlers can ACK on the still-open connection) before the enumerable completes, instead of stopping immediately.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>An async enumerable of messages from the consumer group.</returns>
     public static async IAsyncEnumerable<INatsJSMsg<T>> ConsumePcgElasticAsync<T>(
@@ -111,6 +112,7 @@ public static class NatsPcgElasticExtensions
         string memberName,
         INatsDeserialize<T>? serializer = null,
         ConsumerConfig? config = null,
+        bool drainOnCancel = false,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var groupConfig = await GetPcgElasticConfigAsync(js, streamName, consumerGroupName, cancellationToken).ConfigureAwait(false);
@@ -133,7 +135,8 @@ public static class NatsPcgElasticExtensions
             memberName,
             groupConfig,
             serializer,
-            config);
+            config,
+            drainOnCancel);
 
         try
         {

--- a/src/Synadia.Orbit.PCGroups/PACKAGE.md
+++ b/src/Synadia.Orbit.PCGroups/PACKAGE.md
@@ -160,6 +160,22 @@ Without `DrainSubscriptionsOnDispose`, NATS .NET closes the socket first during
 connection disposal and buffered consumer messages may remain pending until
 `AckWait` expires.
 
+To drain without disposing the connection, pass `drainOnCancel: true` to the
+consume call. Cancelling the supplied token then stops pulling, delivers the
+messages already buffered by the client so handlers can ACK them on the still
+open connection, and completes the enumerable instead of stopping immediately:
+
+```csharp
+using var cts = new CancellationTokenSource();
+
+await foreach (var msg in js.ConsumePcgStaticAsync<string>(
+    streamName, groupName, memberName, drainOnCancel: true, cancellationToken: cts.Token))
+{
+    // cts.Cancel() lets the buffered messages drain through this loop before it ends.
+    await msg.AckAsync();
+}
+```
+
 ## Custom Partition Mappings
 
 For fine-grained control over partition distribution:

--- a/src/Synadia.Orbit.PCGroups/PACKAGE.md
+++ b/src/Synadia.Orbit.PCGroups/PACKAGE.md
@@ -161,9 +161,11 @@ connection disposal and buffered consumer messages may remain pending until
 `AckWait` expires.
 
 To drain without disposing the connection, pass `drainOnCancel: true` to the
-consume call. Cancelling the supplied token then stops pulling, delivers the
-messages already buffered by the client so handlers can ACK them on the still
-open connection, and completes the enumerable instead of stopping immediately:
+consume call. A graceful stop then stops pulling, delivers the messages already
+buffered by the client so handlers can ACK them on the still open connection,
+and completes the enumerable instead of stopping immediately. A graceful stop is
+either cancelling the supplied token or an internal lifecycle event such as a
+membership change; buffered messages are valid for this consumer either way:
 
 ```csharp
 using var cts = new CancellationTokenSource();

--- a/src/Synadia.Orbit.PCGroups/Static/NatsPcgStaticConsumeContext.cs
+++ b/src/Synadia.Orbit.PCGroups/Static/NatsPcgStaticConsumeContext.cs
@@ -22,6 +22,7 @@ internal sealed class NatsPcgStaticConsumeContext<T> : IAsyncEnumerable<NatsPcgM
     private readonly string _memberName;
     private readonly INatsDeserialize<T>? _serializer;
     private readonly ConsumerConfig? _userConfig;
+    private readonly bool _drainOnCancel;
 
     private readonly CancellationTokenSource _cts = new();
 
@@ -37,7 +38,8 @@ internal sealed class NatsPcgStaticConsumeContext<T> : IAsyncEnumerable<NatsPcgM
         string memberName,
         NatsPcgStaticConfig config,
         INatsDeserialize<T>? serializer,
-        ConsumerConfig? userConfig)
+        ConsumerConfig? userConfig,
+        bool drainOnCancel)
     {
         _js = js;
         _streamName = streamName;
@@ -46,6 +48,7 @@ internal sealed class NatsPcgStaticConsumeContext<T> : IAsyncEnumerable<NatsPcgM
         _config = config;
         _serializer = serializer;
         _userConfig = userConfig;
+        _drainOnCancel = drainOnCancel;
     }
 
     public async ValueTask DisposeAsync()
@@ -136,6 +139,7 @@ internal sealed class NatsPcgStaticConsumeContext<T> : IAsyncEnumerable<NatsPcgM
                     Expires = NatsPcgConstants.PullTimeout,
                     IdleHeartbeat = TimeSpan.FromMilliseconds(NatsPcgConstants.PullTimeout.TotalMilliseconds / 2),
                     PriorityGroup = priorityGroup,
+                    DrainOnCancel = _drainOnCancel,
                 };
 
                 messages = _consumer.ConsumeAsync(_serializer, consumeOpts, linkedToken);
@@ -178,7 +182,10 @@ internal sealed class NatsPcgStaticConsumeContext<T> : IAsyncEnumerable<NatsPcgM
 
                     if (!hasNext)
                     {
-                        if (_js.Connection.Opts.DrainSubscriptionsOnDispose)
+                        // Underlying consume completed. When cancelled with DrainOnCancel,
+                        // the client has already flushed buffered messages, so finish here
+                        // instead of looping back to recreate the consumer.
+                        if (linkedToken.IsCancellationRequested || _js.Connection.Opts.DrainSubscriptionsOnDispose)
                         {
                             yield break;
                         }
@@ -186,7 +193,9 @@ internal sealed class NatsPcgStaticConsumeContext<T> : IAsyncEnumerable<NatsPcgM
                         break;
                     }
 
-                    if (_stopped || linkedToken.IsCancellationRequested)
+                    // While draining on cancel keep yielding the buffered messages the
+                    // client hands us; the loop ends when MoveNextAsync reports completion.
+                    if (!_drainOnCancel && (_stopped || linkedToken.IsCancellationRequested))
                     {
                         yield break;
                     }

--- a/src/Synadia.Orbit.PCGroups/Static/NatsPcgStaticExtensions.cs
+++ b/src/Synadia.Orbit.PCGroups/Static/NatsPcgStaticExtensions.cs
@@ -98,6 +98,7 @@ public static class NatsPcgStaticExtensions
     /// <param name="memberName">Name of this member.</param>
     /// <param name="serializer">Optional deserializer for message data.</param>
     /// <param name="config">Optional consumer configuration overrides.</param>
+    /// <param name="drainOnCancel">When true, cancelling <paramref name="cancellationToken"/> drains the consumer gracefully (stop pulling, deliver buffered messages so handlers can ACK on the still-open connection) before the enumerable completes, instead of stopping immediately.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>An async enumerable of messages from the consumer group.</returns>
     public static async IAsyncEnumerable<INatsJSMsg<T>> ConsumePcgStaticAsync<T>(
@@ -107,6 +108,7 @@ public static class NatsPcgStaticExtensions
         string memberName,
         INatsDeserialize<T>? serializer = null,
         ConsumerConfig? config = null,
+        bool drainOnCancel = false,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var groupConfig = await GetPcgStaticConfigAsync(js, streamName, consumerGroupName, cancellationToken).ConfigureAwait(false);
@@ -123,7 +125,8 @@ public static class NatsPcgStaticExtensions
             memberName,
             groupConfig,
             serializer,
-            config);
+            config,
+            drainOnCancel);
 
         try
         {

--- a/src/Synadia.Orbit.PCGroups/Static/NatsPcgStaticExtensions.cs
+++ b/src/Synadia.Orbit.PCGroups/Static/NatsPcgStaticExtensions.cs
@@ -98,7 +98,7 @@ public static class NatsPcgStaticExtensions
     /// <param name="memberName">Name of this member.</param>
     /// <param name="serializer">Optional deserializer for message data.</param>
     /// <param name="config">Optional consumer configuration overrides.</param>
-    /// <param name="drainOnCancel">When true, cancelling <paramref name="cancellationToken"/> drains the consumer gracefully (stop pulling, deliver buffered messages so handlers can ACK on the still-open connection) before the enumerable completes, instead of stopping immediately.</param>
+    /// <param name="drainOnCancel">When true, a graceful stop (cancelling <paramref name="cancellationToken"/>, or an internal lifecycle event such as a membership change) drains the consumer (stop pulling, deliver buffered messages so handlers can ACK on the still-open connection) before the enumerable completes, instead of stopping immediately.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>An async enumerable of messages from the consumer group.</returns>
     public static async IAsyncEnumerable<INatsJSMsg<T>> ConsumePcgStaticAsync<T>(

--- a/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
@@ -768,12 +768,10 @@ public class NatsPcgElasticExtensionsTests
 
             await TaskTestHelpers.AssertCompletesWithinAsync(consumeTask, TimeSpan.FromSeconds(10));
 
+            // Buffered messages kept flowing through the enumerable after dispose
+            // started; acks during the drain did not throw (the consume task above
+            // completed without faulting).
             Assert.True(Volatile.Read(ref consumed) > bailAt, $"consumed {Volatile.Read(ref consumed)} should be greater than {bailAt}");
-
-            await using var check = new NatsConnection(new NatsOpts { Url = _server.Url });
-            var checkJs = check.CreateJetStreamContext();
-            var consumer = await checkJs.GetConsumerAsync(workQueueStreamName, "worker");
-            Assert.Equal(0, consumer.Info.NumAckPending);
         }
         finally
         {
@@ -857,16 +855,16 @@ public class NatsPcgElasticExtensionsTests
 
             await TaskTestHelpers.AssertCompletesWithinAsync(consumeTask, TimeSpan.FromSeconds(10));
 
+            // Drain delivered buffered messages past the bail point instead of
+            // dropping them on cancel, and acks during the drain did not throw.
             Assert.True(Volatile.Read(ref consumed) > bailAt, $"consumed {Volatile.Read(ref consumed)} should be greater than {bailAt}");
 
-            // Acks are published without a server round-trip; ping the consuming
-            // connection to flush the drained acks before checking server state.
+            // Connection stays usable after a drain-on-cancel completes.
+            Assert.Equal(NatsConnectionState.Open, nats.ConnectionState);
             await nats.PingAsync();
-
-            await using var check = new NatsConnection(new NatsOpts { Url = _server.Url });
-            var checkJs = check.CreateJetStreamContext();
-            var consumer = await checkJs.GetConsumerAsync(workQueueStreamName, "worker");
-            Assert.Equal(0, consumer.Info.NumAckPending);
+            var ack = await js.PublishAsync($"{id}.orders.post-drain", "after", cancellationToken: CancellationToken.None);
+            Assert.Null(ack.Error);
+            Assert.True(ack.Seq > 0, "post-drain publish should be stored on the open connection");
         }
         finally
         {

--- a/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
@@ -859,6 +859,10 @@ public class NatsPcgElasticExtensionsTests
 
             Assert.True(Volatile.Read(ref consumed) > bailAt, $"consumed {Volatile.Read(ref consumed)} should be greater than {bailAt}");
 
+            // Acks are published without a server round-trip; ping the consuming
+            // connection to flush the drained acks before checking server state.
+            await nats.PingAsync();
+
             await using var check = new NatsConnection(new NatsOpts { Url = _server.Url });
             var checkJs = check.CreateJetStreamContext();
             var consumer = await checkJs.GetConsumerAsync(workQueueStreamName, "worker");

--- a/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
@@ -786,6 +786,93 @@ public class NatsPcgElasticExtensionsTests
     }
 
     [Fact]
+    public async Task ConsumeElastic_DrainOnCancelDeliversBufferedMessagesAndCompletes()
+    {
+        const int totalMsgs = 30;
+        const int bailAt = 5;
+
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var js = nats.CreateJetStreamContext();
+
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
+        var subject = $"{id}.orders.*";
+        var groupName = $"test-group-{id}";
+        var workQueueStreamName = $"{streamName}-{groupName}";
+
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = [subject],
+        });
+
+        await js.CreatePcgElasticAsync(
+            streamName,
+            groupName,
+            maxNumMembers: 1,
+            partitioningFilters: [new NatsPcgPartitioningFilter(subject, [1])]);
+
+        await js.AddPcgElasticMembersAsync(streamName, groupName, ["worker"]);
+
+        for (var i = 0; i < totalMsgs; i++)
+        {
+            await js.PublishAsync($"{id}.orders.{i}", $"payload-{i}");
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var consumed = 0;
+        var reachedBail = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseAfterCancelStarts = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var consumeTask = Task.Run(
+            async () =>
+            {
+                try
+                {
+                    await foreach (var msg in js.ConsumePcgElasticAsync<string>(streamName, groupName, "worker", drainOnCancel: true, cancellationToken: cts.Token))
+                    {
+                        Interlocked.Increment(ref consumed);
+
+                        // Ack on the still-open connection; the consume token is cancelled mid-drain.
+                        await msg.AckAsync(cancellationToken: CancellationToken.None);
+
+                        if (Volatile.Read(ref consumed) == bailAt)
+                        {
+                            reachedBail.TrySetResult(true);
+                            await releaseAfterCancelStarts.Task.ConfigureAwait(false);
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            });
+
+        try
+        {
+            await TaskTestHelpers.AssertCompletesWithinAsync(reachedBail.Task, TimeSpan.FromSeconds(10));
+
+            cts.Cancel();
+            releaseAfterCancelStarts.TrySetResult(true);
+
+            await TaskTestHelpers.AssertCompletesWithinAsync(consumeTask, TimeSpan.FromSeconds(10));
+
+            Assert.True(Volatile.Read(ref consumed) > bailAt, $"consumed {Volatile.Read(ref consumed)} should be greater than {bailAt}");
+
+            await using var check = new NatsConnection(new NatsOpts { Url = _server.Url });
+            var checkJs = check.CreateJetStreamContext();
+            var consumer = await checkJs.GetConsumerAsync(workQueueStreamName, "worker");
+            Assert.Equal(0, consumer.Info.NumAckPending);
+        }
+        finally
+        {
+            releaseAfterCancelStarts.TrySetResult(true);
+            cts.Cancel();
+            await Task.WhenAny(consumeTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        }
+    }
+
+    [Fact]
     public async Task CreatePcgElastic_EmptyWildcards_FullSubjectPartition_Success()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });

--- a/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
@@ -1011,7 +1011,10 @@ public class NatsPcgElasticExtensionsTests
                 await js.PublishAsync($"ewp{id}.item{i}", $"payload{i}");
             }
 
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            // Generous budget: two elastic members must spin up consumers and the
+            // partitions must distribute; the wait loop below exits as soon as all
+            // 20 arrive, so this only caps the worst case on slow runners.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             var memberAMessages = new List<string>();
             var memberBMessages = new List<string>();
 
@@ -1073,7 +1076,7 @@ public class NatsPcgElasticExtensionsTests
             var memberARound2 = new List<string>();
             var memberBRound2 = new List<string>();
 
-            using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
             var taskA2 = Task.Run(async () =>
             {

--- a/tests/Synadia.Orbit.PCGroups.Test/Static/NatsPcgStaticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Static/NatsPcgStaticExtensionsTests.cs
@@ -620,12 +620,10 @@ public class NatsPcgStaticExtensionsTests
 
             await TaskTestHelpers.AssertCompletesWithinAsync(consumeTask, TimeSpan.FromSeconds(10));
 
+            // Buffered messages kept flowing through the enumerable after dispose
+            // started; acks during the drain did not throw (the consume task above
+            // completed without faulting).
             Assert.True(Volatile.Read(ref consumed) > bailAt, $"consumed {Volatile.Read(ref consumed)} should be greater than {bailAt}");
-
-            await using var check = new NatsConnection(new NatsOpts { Url = _server.Url });
-            var checkJs = check.CreateJetStreamContext();
-            var consumer = await checkJs.GetConsumerAsync(streamName, $"{groupName}-worker");
-            Assert.Equal(0, consumer.Info.NumAckPending);
         }
         finally
         {
@@ -712,16 +710,16 @@ public class NatsPcgStaticExtensionsTests
 
             await TaskTestHelpers.AssertCompletesWithinAsync(consumeTask, TimeSpan.FromSeconds(10));
 
+            // Drain delivered buffered messages past the bail point instead of
+            // dropping them on cancel, and acks during the drain did not throw.
             Assert.True(Volatile.Read(ref consumed) > bailAt, $"consumed {Volatile.Read(ref consumed)} should be greater than {bailAt}");
 
-            // Acks are published without a server round-trip; ping the consuming
-            // connection to flush the drained acks before checking server state.
+            // Connection stays usable after a drain-on-cancel completes.
+            Assert.Equal(NatsConnectionState.Open, nats.ConnectionState);
             await nats.PingAsync();
-
-            await using var check = new NatsConnection(new NatsOpts { Url = _server.Url });
-            var checkJs = check.CreateJetStreamContext();
-            var consumer = await checkJs.GetConsumerAsync(streamName, $"{groupName}-worker");
-            Assert.Equal(0, consumer.Info.NumAckPending);
+            var ack = await js.PublishAsync($"{id}.orders.post-drain", "after", cancellationToken: CancellationToken.None);
+            Assert.Null(ack.Error);
+            Assert.True(ack.Seq > 0, "post-drain publish should be stored on the open connection");
         }
         finally
         {

--- a/tests/Synadia.Orbit.PCGroups.Test/Static/NatsPcgStaticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Static/NatsPcgStaticExtensionsTests.cs
@@ -636,4 +636,94 @@ public class NatsPcgStaticExtensionsTests
             await Task.WhenAny(consumeTask, Task.Delay(TimeSpan.FromSeconds(5)));
         }
     }
+
+    [Fact]
+    public async Task ConsumeStatic_DrainOnCancelDeliversBufferedMessagesAndCompletes()
+    {
+        const int totalMsgs = 30;
+        const int bailAt = 5;
+
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var js = nats.CreateJetStreamContext();
+
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
+        var subject = $"{id}.orders.*";
+        var groupName = $"test-group-{id}";
+
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = [subject],
+            SubjectTransform = new SubjectTransform
+            {
+                Src = subject,
+                Dest = $"{{{{partition(1,1)}}}}.{id}.orders.{{{{wildcard(1)}}}}",
+            },
+        });
+
+        await js.CreatePcgStaticAsync(
+            streamName,
+            groupName,
+            maxNumMembers: 1,
+            filters: [subject],
+            members: ["worker"]);
+
+        for (var i = 0; i < totalMsgs; i++)
+        {
+            await js.PublishAsync($"{id}.orders.{i}", $"payload-{i}");
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var consumed = 0;
+        var reachedBail = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseAfterCancelStarts = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var consumeTask = Task.Run(
+            async () =>
+            {
+                try
+                {
+                    await foreach (var msg in js.ConsumePcgStaticAsync<string>(streamName, groupName, "worker", drainOnCancel: true, cancellationToken: cts.Token))
+                    {
+                        Interlocked.Increment(ref consumed);
+
+                        // Ack on the still-open connection; the consume token is cancelled mid-drain.
+                        await msg.AckAsync(cancellationToken: CancellationToken.None);
+
+                        if (Volatile.Read(ref consumed) == bailAt)
+                        {
+                            reachedBail.TrySetResult(true);
+                            await releaseAfterCancelStarts.Task.ConfigureAwait(false);
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            });
+
+        try
+        {
+            await TaskTestHelpers.AssertCompletesWithinAsync(reachedBail.Task, TimeSpan.FromSeconds(10));
+
+            cts.Cancel();
+            releaseAfterCancelStarts.TrySetResult(true);
+
+            await TaskTestHelpers.AssertCompletesWithinAsync(consumeTask, TimeSpan.FromSeconds(10));
+
+            Assert.True(Volatile.Read(ref consumed) > bailAt, $"consumed {Volatile.Read(ref consumed)} should be greater than {bailAt}");
+
+            await using var check = new NatsConnection(new NatsOpts { Url = _server.Url });
+            var checkJs = check.CreateJetStreamContext();
+            var consumer = await checkJs.GetConsumerAsync(streamName, $"{groupName}-worker");
+            Assert.Equal(0, consumer.Info.NumAckPending);
+        }
+        finally
+        {
+            releaseAfterCancelStarts.TrySetResult(true);
+            cts.Cancel();
+            await Task.WhenAny(consumeTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        }
+    }
 }

--- a/tests/Synadia.Orbit.PCGroups.Test/Static/NatsPcgStaticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Static/NatsPcgStaticExtensionsTests.cs
@@ -714,6 +714,10 @@ public class NatsPcgStaticExtensionsTests
 
             Assert.True(Volatile.Read(ref consumed) > bailAt, $"consumed {Volatile.Read(ref consumed)} should be greater than {bailAt}");
 
+            // Acks are published without a server round-trip; ping the consuming
+            // connection to flush the drained acks before checking server state.
+            await nats.PingAsync();
+
             await using var check = new NatsConnection(new NatsOpts { Url = _server.Url });
             var checkJs = check.CreateJetStreamContext();
             var consumer = await checkJs.GetConsumerAsync(streamName, $"{groupName}-worker");


### PR DESCRIPTION
Adds an opt-in drainOnCancel parameter to the static and elastic PCGroups consume methods, mirroring NatsJSConsumeOpts.DrainOnCancel. When set, a graceful stop (cancelling the consume token, or an internal lifecycle event such as a membership change) stops pulling, delivers messages already buffered by the client so handlers can still ACK on the open connection, then completes the enumerable instead of stopping abruptly. Default is false, preserving current behavior.

Fixes #68