### PR TITLE
Recreate elastic PCG consumer on membership change

### DIFF
--- a/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticConsumeContext.cs
+++ b/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticConsumeContext.cs
@@ -32,6 +32,8 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
     private Task? _watchTask;
     private volatile bool _stopped;
     private volatile bool _needsRecreate;
+    private volatile string? _currentPinnedId;
+    private volatile CancellationTokenSource? _recreateCts;
     private string[] _currentFilters = Array.Empty<string>();
 
     public NatsPcgElasticConsumeContext(
@@ -123,6 +125,7 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
             }
 
             IAsyncEnumerable<INatsJSMsg<T>> messages;
+            CancellationTokenSource? consumeCts = null;
 
             try
             {
@@ -181,14 +184,22 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
                     DrainOnCancel = _drainOnCancel,
                 };
 
-                messages = _consumer.ConsumeAsync(_serializer, consumeOpts, linkedToken);
+                // Linked source so a membership change can interrupt an idle consume
+                // without tearing down the caller's or the context's cancellation.
+                consumeCts = CancellationTokenSource.CreateLinkedTokenSource(linkedToken);
+                _recreateCts = consumeCts;
+
+                messages = _consumer.ConsumeAsync(_serializer, consumeOpts, consumeCts.Token);
             }
             catch (OperationCanceledException) when (linkedToken.IsCancellationRequested)
             {
+                consumeCts?.Dispose();
                 yield break;
             }
             catch (NatsJSApiException ex) when (ex.Error.Code == 404)
             {
+                consumeCts?.Dispose();
+
                 // Consumer deleted - this is expected when membership changes
                 if (!_stopped && !linkedToken.IsCancellationRequested)
                 {
@@ -202,7 +213,7 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
             IAsyncEnumerator<INatsJSMsg<T>>? enumerator = null;
             try
             {
-                enumerator = messages.GetAsyncEnumerator(linkedToken);
+                enumerator = messages.GetAsyncEnumerator(consumeCts.Token);
                 while (true)
                 {
                     bool hasNext;
@@ -213,6 +224,11 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
                     catch (OperationCanceledException) when (linkedToken.IsCancellationRequested)
                     {
                         yield break;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // Membership change interrupted an idle consume; re-evaluate
+                        break;
                     }
                     catch (NatsJSApiException ex) when (ex.Error.Code == 404)
                     {
@@ -254,16 +270,21 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
                     }
 
                     var msg = enumerator.Current;
+                    TrackPinnedId(msg);
                     string strippedSubject = NatsPcgMsg<T>.StripPartitionPrefix(msg.Subject);
                     yield return new NatsPcgMsg<T>((NatsJSMsg<T>)msg, strippedSubject);
                 }
             }
             finally
             {
+                _recreateCts = null;
+
                 if (enumerator != null)
                 {
                     await enumerator.DisposeAsync().ConfigureAwait(false);
                 }
+
+                consumeCts?.Dispose();
             }
         }
     }
@@ -282,20 +303,7 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
 
         string workQueueStreamName = NatsPcgElasticExtensions.GetWorkQueueStreamName(_streamName, _consumerGroupName);
 
-        // Each member gets its own consumer (named after the member)
-        string consumerName = _memberName;
-
-        var consumerConfig = new ConsumerConfig(consumerName)
-        {
-            AckPolicy = _userConfig?.AckPolicy ?? ConsumerConfigAckPolicy.Explicit,
-            AckWait = _userConfig?.AckWait ?? NatsPcgConstants.AckWait,
-            MaxDeliver = _userConfig?.MaxDeliver ?? -1,
-            FilterSubjects = filters,
-            PriorityGroups = new[] { NatsPcgConstants.PriorityGroupName },
-            PriorityPolicy = ConsumerConfigPriorityPolicy.PinnedClient,
-            PinnedTTL = NatsPcgConstants.ConsumerIdleTimeout,
-            InactiveThreshold = NatsPcgConstants.ConsumerIdleTimeout,
-        };
+        var consumerConfig = BuildConsumerConfig(filters);
 
         try
         {
@@ -304,7 +312,7 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
         catch (NatsJSApiException ex) when (ex.Error.Code == 400)
         {
             // Consumer might already exist with different filter - try to get it
-            _consumer = await _js.GetConsumerAsync(workQueueStreamName, consumerName, cancellationToken).ConfigureAwait(false);
+            _consumer = await _js.GetConsumerAsync(workQueueStreamName, _memberName, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -327,20 +335,49 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
         // Recalculate filters
         string[] filters = GenerateFiltersForMember(config, _memberName);
 
-        // Only recreate if filters changed
+        // Only recreate if filters changed. Unchanged filters mean this member's
+        // partition set is identical, so the existing consumer is still correct.
         if (FiltersEqual(filters, _currentFilters))
         {
             return;
         }
 
-        _currentFilters = filters;
-
+        // Just updating the filters on the existing consumer is not enough: a newly
+        // assigned partition may have messages at stream sequences the consumer has
+        // already advanced past, which would be silently skipped. The consumer must be
+        // deleted and recreated so it restarts from the correct position. Only the pinned
+        // member performs the delete; others back off so the pinned member wins the race
+        // and to avoid flapping. A consumer that is briefly missing or fails the
+        // not-unique check is a normal rebalance condition handled by retry/self-heal.
         string workQueueStreamName = NatsPcgElasticExtensions.GetWorkQueueStreamName(_streamName, _consumerGroupName);
 
-        // Each member gets its own consumer (named after the member)
-        string consumerName = _memberName;
+        bool isPinned = await IsCurrentlyPinnedAsync().ConfigureAwait(false);
 
-        var consumerConfig = new ConsumerConfig(consumerName)
+        if (isPinned)
+        {
+            try
+            {
+                await _js.DeleteConsumerAsync(workQueueStreamName, _memberName, _cts.Token).ConfigureAwait(false);
+            }
+            catch (NatsJSApiException ex) when (ex.Error.Code == 404)
+            {
+                // Already gone - normal during rebalance
+            }
+        }
+        else
+        {
+            // Give the pinned member a chance to delete and recreate first
+            await Task.Delay(GetMembershipBackoffDelay(), _cts.Token).ConfigureAwait(false);
+        }
+
+        _consumer = await TryCreateConsumerAsync(workQueueStreamName, filters).ConfigureAwait(false);
+        _currentFilters = filters;
+    }
+
+    private ConsumerConfig BuildConsumerConfig(string[] filters)
+    {
+        // Each member gets its own consumer (named after the member)
+        return new ConsumerConfig(_memberName)
         {
             AckPolicy = _userConfig?.AckPolicy ?? ConsumerConfigAckPolicy.Explicit,
             AckWait = _userConfig?.AckWait ?? NatsPcgConstants.AckWait,
@@ -351,8 +388,92 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
             PinnedTTL = NatsPcgConstants.ConsumerIdleTimeout,
             InactiveThreshold = NatsPcgConstants.ConsumerIdleTimeout,
         };
+    }
 
-        _consumer = await _js.CreateOrUpdateConsumerAsync(workQueueStreamName, consumerConfig, _cts.Token).ConfigureAwait(false);
+    // Mirrors the Go tryCreateConsumer: create with the desired config; if a consumer
+    // already exists (possibly with stale filters left by another member), delete it and
+    // create again so we end up with the correct position and filters.
+    private async Task<INatsJSConsumer> TryCreateConsumerAsync(string workQueueStreamName, string[] filters)
+    {
+        var consumerConfig = BuildConsumerConfig(filters);
+
+        try
+        {
+            return await _js.CreateConsumerAsync(workQueueStreamName, consumerConfig, _cts.Token).ConfigureAwait(false);
+        }
+        catch (NatsJSApiException ex) when (ex.Error.Code == 400 || ex.Error.ErrCode == NatsPcgConstants.WqConsumerNotUniqueErrCode)
+        {
+            try
+            {
+                await _js.DeleteConsumerAsync(workQueueStreamName, _memberName, _cts.Token).ConfigureAwait(false);
+            }
+            catch (NatsJSApiException delEx) when (delEx.Error.Code == 404)
+            {
+                // Already gone - fall through to recreate
+            }
+
+            return await _js.CreateConsumerAsync(workQueueStreamName, consumerConfig, _cts.Token).ConfigureAwait(false);
+        }
+    }
+
+    // Determines whether this member currently holds the pinned client slot, by comparing
+    // the pinned id last seen on a delivered message against the consumer's reported state.
+    private async Task<bool> IsCurrentlyPinnedAsync()
+    {
+        string? pinnedId = _currentPinnedId;
+        if (string.IsNullOrEmpty(pinnedId) || _consumer == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            await _consumer.RefreshAsync(_cts.Token).ConfigureAwait(false);
+        }
+        catch
+        {
+            // The consumer may not exist yet; treat as not pinned (matches Go)
+            return false;
+        }
+
+        var groups = _consumer.Info.PriorityGroups;
+        if (groups == null)
+        {
+            return false;
+        }
+
+        foreach (var group in groups)
+        {
+            if (group.Group == NatsPcgConstants.PriorityGroupName && group.PinnedClientId == pinnedId)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void TrackPinnedId(INatsJSMsg<T> msg)
+    {
+        if (msg.Headers != null && msg.Headers.TryGetValue(NatsPcgConstants.PinIdHeader, out var pinId) && pinId.Count > 0)
+        {
+            _currentPinnedId = pinId.ToString();
+        }
+    }
+
+    // Flags a membership-driven recreate and interrupts an idle/blocked consume so the
+    // consume loop re-evaluates promptly instead of waiting for the next message.
+    private void SignalRecreate()
+    {
+        _needsRecreate = true;
+        try
+        {
+            _recreateCts?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Consume loop already moved on; the flag will be picked up at the loop top
+        }
     }
 
     private static string[] GenerateFiltersForMember(NatsPcgElasticConfig config, string memberName)
@@ -442,8 +563,9 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
                                 break;
                             }
 
-                            // Signal that we need to check if consumer needs recreation
-                            _needsRecreate = true;
+                            // Signal that we need to check if consumer needs recreation,
+                            // interrupting an idle consume so the change is picked up promptly
+                            SignalRecreate();
                         }
                     }
                 }
@@ -504,6 +626,19 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
             delayMs = s_random.Next(
                 (int)NatsPcgConstants.MinReconnectDelay.TotalMilliseconds,
                 (int)NatsPcgConstants.MaxReconnectDelay.TotalMilliseconds);
+        }
+
+        return TimeSpan.FromMilliseconds(delayMs);
+    }
+
+    private static TimeSpan GetMembershipBackoffDelay()
+    {
+        int delayMs;
+        lock (s_random)
+        {
+            delayMs = s_random.Next(
+                (int)NatsPcgConstants.MembershipBackoffMin.TotalMilliseconds,
+                (int)NatsPcgConstants.MembershipBackoffMax.TotalMilliseconds);
         }
 
         return TimeSpan.FromMilliseconds(delayMs);

--- a/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticConsumeContext.cs
+++ b/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticConsumeContext.cs
@@ -213,7 +213,9 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
             IAsyncEnumerator<INatsJSMsg<T>>? enumerator = null;
             try
             {
-                enumerator = messages.GetAsyncEnumerator(consumeCts.Token);
+                // consumeCts is always assigned before messages is set above; the catch
+                // blocks all exit, so reaching here guarantees it is non-null.
+                enumerator = messages.GetAsyncEnumerator(consumeCts!.Token);
                 while (true)
                 {
                     bool hasNext;
@@ -363,6 +365,11 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
             {
                 // Already gone - normal during rebalance
             }
+
+            // The consumer is gone; drop the stale reference so that if the recreate
+            // below throws, the consume loop's self-heal path rejoins instead of
+            // consuming a deleted consumer and waiting for a 404 to retry.
+            _consumer = null;
         }
         else
         {
@@ -401,8 +408,10 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
         {
             return await _js.CreateConsumerAsync(workQueueStreamName, consumerConfig, _cts.Token).ConfigureAwait(false);
         }
-        catch (NatsJSApiException ex) when (ex.Error.Code == 400 || ex.Error.ErrCode == NatsPcgConstants.WqConsumerNotUniqueErrCode)
+        catch (NatsJSApiException ex) when (Array.IndexOf(NatsPcgConstants.ConsumerCreateConflictErrCodes, ex.Error.ErrCode) >= 0)
         {
+            // A consumer with this name already exists (stale filters left by us or
+            // another member). Delete it and create again with the desired config.
             try
             {
                 await _js.DeleteConsumerAsync(workQueueStreamName, _memberName, _cts.Token).ConfigureAwait(false);
@@ -412,6 +421,9 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
                 // Already gone - fall through to recreate
             }
 
+            // Second attempt. If another member races us and recreates the consumer in
+            // the window between delete and create, this throws; the outer consume loop
+            // catches it, backs off, and retries the recreate.
             return await _js.CreateConsumerAsync(workQueueStreamName, consumerConfig, _cts.Token).ConfigureAwait(false);
         }
     }

--- a/src/Synadia.Orbit.PCGroups/NatsPcgConstants.cs
+++ b/src/Synadia.Orbit.PCGroups/NatsPcgConstants.cs
@@ -24,6 +24,17 @@ internal static class NatsPcgConstants
     internal const string PriorityGroupName = "PCG";
 
     /// <summary>
+    /// Message header carrying the server-assigned pinned client id.
+    /// </summary>
+    internal const string PinIdHeader = "Nats-Pin-Id";
+
+    /// <summary>
+    /// JetStream API error code for a non-unique work queue consumer.
+    /// Can occur transiently while members converge on a membership change.
+    /// </summary>
+    internal const int WqConsumerNotUniqueErrCode = 10100;
+
+    /// <summary>
     /// Default pull request timeout.
     /// </summary>
     internal static readonly TimeSpan PullTimeout = TimeSpan.FromSeconds(3);
@@ -47,6 +58,17 @@ internal static class NatsPcgConstants
     /// Maximum delay for reconnect backoff.
     /// </summary>
     internal static readonly TimeSpan MaxReconnectDelay = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Minimum backoff a non-pinned member waits on a membership change,
+    /// giving the pinned member a chance to delete and recreate the consumer first.
+    /// </summary>
+    internal static readonly TimeSpan MembershipBackoffMin = TimeSpan.FromMilliseconds(400);
+
+    /// <summary>
+    /// Maximum backoff a non-pinned member waits on a membership change.
+    /// </summary>
+    internal static readonly TimeSpan MembershipBackoffMax = TimeSpan.FromMilliseconds(500);
 
     /// <summary>
     /// Interval for self-healing checks.

--- a/src/Synadia.Orbit.PCGroups/NatsPcgConstants.cs
+++ b/src/Synadia.Orbit.PCGroups/NatsPcgConstants.cs
@@ -29,10 +29,18 @@ internal static class NatsPcgConstants
     internal const string PinIdHeader = "Nats-Pin-Id";
 
     /// <summary>
-    /// JetStream API error code for a non-unique work queue consumer.
-    /// Can occur transiently while members converge on a membership change.
+    /// JetStream API error codes that mean a consumer with the requested name already
+    /// exists (with a different config, still active, or name in use) or that a filtered
+    /// work queue consumer would not be unique. All can occur transiently while members
+    /// converge on a membership change and are handled by delete-then-recreate.
     /// </summary>
-    internal const int WqConsumerNotUniqueErrCode = 10100;
+    internal static readonly int[] ConsumerCreateConflictErrCodes =
+    {
+        10148, // consumer already exists (CREATE with a different config)
+        10013, // consumer name already in use
+        10105, // consumer already exists and is still active
+        10100, // filtered consumer not unique on workqueue stream
+    };
 
     /// <summary>
     /// Default pull request timeout.

--- a/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticExtensionsTests.cs
@@ -1141,6 +1141,116 @@ public class NatsPcgElasticExtensionsTests
         }
     }
 
+    [Fact]
+    public async Task ConsumeElastic_MemberGainingPartition_ReceivesMessagesBehindConsumerPosition()
+    {
+        // Regression for the membership-change skip bug: when a member gains a partition,
+        // updating the existing consumer's filters is not enough because the consumer may
+        // have already advanced its stream position past messages of the new partition.
+        // The consumer must be deleted and recreated so it rescans from the start.
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var js = nats.CreateJetStreamContext();
+
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"test-stream-{id}";
+
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = [$"mgp{id}.*"],
+        });
+
+        try
+        {
+            var groupName = $"test-group-{id}";
+
+            // 2 partitions, 2 members: A owns partition 0, B owns partition 1.
+            await js.CreatePcgElasticAsync(
+                streamName,
+                groupName,
+                maxNumMembers: 2,
+                partitioningFilters: [new NatsPcgPartitioningFilter($"mgp{id}.*", [1])]);
+
+            await js.AddPcgElasticMembersAsync(streamName, groupName, ["a", "b"]);
+
+            // Publish across many distinct keys so both partitions receive messages,
+            // interleaved so partition-1 messages sit before A's last partition-0 message.
+            const int messageCount = 60;
+            for (int i = 0; i < messageCount; i++)
+            {
+                await js.PublishAsync($"mgp{id}.key{i}", $"payload-{i}");
+            }
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(40));
+            var received = new System.Collections.Concurrent.ConcurrentDictionary<string, byte>();
+
+            // Only member A consumes; B is a member (so partition 1 is assigned to B and
+            // its messages accumulate unconsumed) but never starts a consumer.
+            var consumeTask = Task.Run(async () =>
+            {
+                try
+                {
+                    await foreach (var msg in js.ConsumePcgElasticAsync<string>(streamName, groupName, "a", cancellationToken: cts.Token))
+                    {
+                        received.TryAdd(msg.Data!, 0);
+                        await msg.AckAsync(cancellationToken: cts.Token);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            });
+
+            // Wait for A to drain its partition (partition 0): count climbs then stays
+            // flat. Once flat, A's consumer position has advanced past the partition-1
+            // messages still sitting in the work queue.
+            int stableCount = -1;
+            int stableFor = 0;
+            while (!cts.Token.IsCancellationRequested)
+            {
+                await Task.Delay(300, cts.Token);
+                int now = received.Count;
+                if (now == stableCount && now > 0)
+                {
+                    stableFor++;
+                    if (stableFor >= 5)
+                    {
+                        break;
+                    }
+                }
+                else
+                {
+                    stableCount = now;
+                    stableFor = 0;
+                }
+            }
+
+            int afterDrain = received.Count;
+            Assert.True(afterDrain > 0, "member a should have consumed its own partition");
+            Assert.True(afterDrain < messageCount, $"member a should not yet have all messages (got {afterDrain}); partition 1 belongs to b");
+
+            // Remove b: partition 1 is reassigned to a. a must now receive the messages
+            // that are behind its consumer position.
+            await js.DeletePcgElasticMembersAsync(streamName, groupName, ["b"]);
+
+            while (received.Count < messageCount && !cts.Token.IsCancellationRequested)
+            {
+                await Task.Delay(200, cts.Token);
+            }
+
+            cts.Cancel();
+            await consumeTask;
+
+            Assert.Equal(messageCount, received.Count);
+
+            await js.DeletePcgElasticAsync(streamName, groupName);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
     private static async Task SkipBelow212Async(NatsConnection nats)
     {
         await nats.ConnectRetryAsync();

--- a/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticGoInteropTests.cs
+++ b/tests/Synadia.Orbit.PCGroups.Test/Elastic/NatsPcgElasticGoInteropTests.cs
@@ -195,6 +195,97 @@ public class NatsPcgElasticGoInteropTests
         }
         """;
 
+    // Consumes continuously until stdin is closed, answering REPORT requests with the
+    // running count so the .NET side can coordinate the phases of a rebalance test.
+    // lang=go
+    private const string GoContinuousConsumerCode =
+        """
+        package main
+
+        import (
+            "bufio"
+            "context"
+            "fmt"
+            "os"
+            "strings"
+            "sync"
+            "time"
+
+            "github.com/nats-io/nats.go"
+            "github.com/nats-io/nats.go/jetstream"
+            "github.com/synadia-io/orbit.go/pcgroups"
+        )
+
+        func main() {
+            reader := bufio.NewReader(os.Stdin)
+            first, err := reader.ReadString('\n')
+            if err != nil {
+                fmt.Fprintln(os.Stderr, "no input")
+                os.Exit(1)
+            }
+
+            parts := strings.Split(strings.TrimSpace(first), "|")
+            natsUrl := parts[0]
+            streamName := parts[1]
+            groupName := parts[2]
+            memberName := parts[3]
+
+            nc, err := nats.Connect(natsUrl)
+            if err != nil {
+                fmt.Fprintf(os.Stderr, "connect: %v\n", err)
+                os.Exit(1)
+            }
+            defer nc.Close()
+
+            js, err := jetstream.New(nc)
+            if err != nil {
+                fmt.Fprintf(os.Stderr, "jetstream: %v\n", err)
+                os.Exit(1)
+            }
+
+            ctx := context.Background()
+
+            var mu sync.Mutex
+            var subjects []string
+
+            consumeCtx, err := pcgroups.ElasticConsume(ctx, js, streamName, groupName, memberName,
+                func(msg jetstream.Msg) {
+                    mu.Lock()
+                    subjects = append(subjects, msg.Subject())
+                    mu.Unlock()
+                    msg.Ack()
+                },
+                jetstream.ConsumerConfig{
+                    AckPolicy: jetstream.AckExplicitPolicy,
+                    AckWait:   5 * time.Second,
+                })
+            if err != nil {
+                fmt.Fprintf(os.Stderr, "consume: %v\n", err)
+                os.Exit(1)
+            }
+            defer consumeCtx.Stop()
+
+            fmt.Println("READY")
+
+            for {
+                line, rerr := reader.ReadString('\n')
+                cmd := strings.TrimSpace(line)
+                if cmd == "REPORT" {
+                    mu.Lock()
+                    fmt.Printf("COUNT:%d\n", len(subjects))
+                    mu.Unlock()
+                }
+                if rerr != nil || cmd == "STOP" {
+                    break
+                }
+            }
+
+            mu.Lock()
+            fmt.Printf("FINAL:count=%d,subjects=%s\n", len(subjects), strings.Join(subjects, ","))
+            mu.Unlock()
+        }
+        """;
+
     private static readonly string[] GoModules =
     [
         "github.com/synadia-io/orbit.go/pcgroups@v0.2.0",
@@ -394,6 +485,139 @@ public class NatsPcgElasticGoInteropTests
             Assert.Contains("count=3", resultLine);
 
             go.CloseInput();
+            await go.WaitForExitAsync(cts.Token);
+            Assert.Equal(0, go.ExitCode);
+
+            await js.DeletePcgElasticAsync(streamName, groupName);
+        }
+        finally
+        {
+            await js.DeleteStreamAsync(streamName);
+        }
+    }
+
+    [Fact]
+    public async Task Mixed_members_split_then_DotNet_takes_over_when_Go_member_removed()
+    {
+        // A .NET member and a Go member share one elastic group and split partitions.
+        // When the Go member is removed, the .NET member must take over its partition
+        // (delete and recreate its consumer) and receive subsequent messages, with no
+        // overlap between the two members' deliveries.
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await SkipBelow211Async(nats);
+        var js = nats.CreateJetStreamContext();
+
+        var id = Guid.NewGuid().ToString("N");
+        var streamName = $"interop-{id}";
+
+        await js.CreateStreamAsync(new StreamConfig
+        {
+            Name = streamName,
+            Subjects = [$"mix{id}.*"],
+        });
+
+        try
+        {
+            var groupName = $"cg-{id}";
+
+            await js.CreatePcgElasticAsync(
+                streamName,
+                groupName,
+                maxNumMembers: 2,
+                partitioningFilters: [new NatsPcgPartitioningFilter($"mix{id}.*", [1])]);
+
+            await js.AddPcgElasticMembersAsync(streamName, groupName, ["dotnet-worker", "go-worker"]);
+
+            const int phase1 = 40;
+            for (int i = 0; i < phase1; i++)
+            {
+                await js.PublishAsync($"mix{id}.k{i}", $"p{i}");
+            }
+
+            await using var go = await GoProcess.RunCodeAsync(
+                GoContinuousConsumerCode,
+                logger: msg => { },
+                goModules: GoModules);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(90));
+
+            await go.WriteLineAsync($"{_server.Url}|{streamName}|{groupName}|go-worker", cts.Token);
+            Assert.Equal("READY", await go.ReadLineAsync(cts.Token));
+
+            var dotnetSubjects = new System.Collections.Concurrent.ConcurrentDictionary<string, byte>();
+            using var consumeCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+            var dotnetTask = Task.Run(async () =>
+            {
+                try
+                {
+                    await foreach (var msg in js.ConsumePcgElasticAsync<string>(streamName, groupName, "dotnet-worker", cancellationToken: consumeCts.Token))
+                    {
+                        dotnetSubjects.TryAdd(msg.Subject, 0);
+                        await msg.AckAsync(cancellationToken: CancellationToken.None);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            });
+
+            async Task<int> GoCountAsync()
+            {
+                await go.WriteLineAsync("REPORT", cts.Token);
+                var line = await go.ReadLineAsync(cts.Token);
+                Assert.NotNull(line);
+                Assert.StartsWith("COUNT:", line);
+                return int.Parse(line!.Substring("COUNT:".Length));
+            }
+
+            // Phase 1: both members consume concurrently and together cover all messages.
+            int goCount = 0;
+            while (!cts.IsCancellationRequested)
+            {
+                goCount = await GoCountAsync();
+                if (dotnetSubjects.Count + goCount >= phase1)
+                {
+                    break;
+                }
+
+                await Task.Delay(300, cts.Token);
+            }
+
+            Assert.Equal(phase1, dotnetSubjects.Count + goCount);
+            Assert.True(dotnetSubjects.Count > 0, ".NET member should own a partition");
+            Assert.True(goCount > 0, "Go member should own a partition");
+            int dotnetPhase1 = dotnetSubjects.Count;
+
+            // Remove the Go member; .NET gains its partition. Give both sides time to
+            // process the membership change before publishing so the new messages are
+            // not delivered to the departing member.
+            await js.DeletePcgElasticMembersAsync(streamName, groupName, ["go-worker"], cts.Token);
+            await Task.Delay(TimeSpan.FromSeconds(2), cts.Token);
+
+            const int phase2 = 20;
+            for (int i = 0; i < phase2; i++)
+            {
+                await js.PublishAsync($"mix{id}.r{i}", $"q{i}");
+            }
+
+            // .NET now owns all partitions and must receive every phase-2 message.
+            while (dotnetSubjects.Count < dotnetPhase1 + phase2 && !cts.IsCancellationRequested)
+            {
+                await Task.Delay(300, cts.Token);
+            }
+
+            Assert.Equal(dotnetPhase1 + phase2, dotnetSubjects.Count);
+
+            // The removed Go member received nothing further.
+            Assert.Equal(goCount, await GoCountAsync());
+
+            consumeCts.Cancel();
+            await dotnetTask;
+
+            go.CloseInput();
+            var finalLine = await go.ReadLineAsync(cts.Token);
+            Assert.NotNull(finalLine);
+            Assert.StartsWith("FINAL:", finalLine);
             await go.WaitForExitAsync(cts.Token);
             Assert.Equal(0, go.ExitCode);
 


### PR DESCRIPTION
When an elastic PCG member gains a partition, updating its consumer's filters in place can skip messages, because the consumer may have already advanced past the stream sequences of the new partition. Delete and recreate the consumer instead so it restarts from the correct position, coordinating the delete through the pinned member and tolerating missing/not-unique consumers as normal rebalance conditions, matching the Go implementation. A consumer that is delivered but unacked when the recreate happens may be redelivered, which can look like a duplicate to consumers not using sync acks.

Fixes #72