### PR TITLE
Release 1.0.0-preview.9

### DIFF
--- a/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticConsumeContext.cs
+++ b/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticConsumeContext.cs
@@ -311,9 +311,11 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
         {
             _consumer = await _js.CreateOrUpdateConsumerAsync(workQueueStreamName, consumerConfig, cancellationToken).ConfigureAwait(false);
         }
-        catch (NatsJSApiException ex) when (ex.Error.Code == 400)
+        catch (NatsJSApiException ex) when (Array.IndexOf(NatsPcgConstants.ConsumerCreateConflictErrCodes, ex.Error.ErrCode) >= 0)
         {
-            // Consumer might already exist with different filter - try to get it
+            // Consumer might already exist with different filter - try to get it. Match the
+            // specific conflict codes rather than any HTTP 400 so a genuine bad-request is not
+            // swallowed and re-surfaced as a misleading 404 from the get.
             _consumer = await _js.GetConsumerAsync(workQueueStreamName, _memberName, cancellationToken).ConfigureAwait(false);
         }
     }
@@ -608,6 +610,9 @@ internal sealed class NatsPcgElasticConsumeContext<T> : IAsyncEnumerable<NatsPcg
         }
     }
 
+    // Ordered element-wise comparison. This relies on GeneratePartitionFilters producing
+    // filters in a stable order for a given partition set; if that ever stops holding, a
+    // reordered-but-equal set would trigger a spurious delete-and-recreate.
     private static bool FiltersEqual(string[] a, string[] b)
     {
         if (a.Length != b.Length)

--- a/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticExtensions.cs
+++ b/src/Synadia.Orbit.PCGroups/Elastic/NatsPcgElasticExtensions.cs
@@ -105,7 +105,7 @@ public static class NatsPcgElasticExtensions
     /// <param name="drainOnCancel">When true, a graceful stop (cancelling <paramref name="cancellationToken"/>, or an internal lifecycle event such as a membership change) drains the consumer (stop pulling, deliver buffered messages so handlers can ACK on the still-open connection) before the enumerable completes, instead of stopping immediately.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>An async enumerable of messages from the consumer group.</returns>
-    public static async IAsyncEnumerable<INatsJSMsg<T>> ConsumePcgElasticAsync<T>(
+    public static async IAsyncEnumerable<NatsPcgMsg<T>> ConsumePcgElasticAsync<T>(
         this INatsJSContext js,
         string streamName,
         string consumerGroupName,

--- a/src/Synadia.Orbit.PCGroups/Static/NatsPcgStaticExtensions.cs
+++ b/src/Synadia.Orbit.PCGroups/Static/NatsPcgStaticExtensions.cs
@@ -101,7 +101,7 @@ public static class NatsPcgStaticExtensions
     /// <param name="drainOnCancel">When true, a graceful stop (cancelling <paramref name="cancellationToken"/>, or an internal lifecycle event such as a membership change) drains the consumer (stop pulling, deliver buffered messages so handlers can ACK on the still-open connection) before the enumerable completes, instead of stopping immediately.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>An async enumerable of messages from the consumer group.</returns>
-    public static async IAsyncEnumerable<INatsJSMsg<T>> ConsumePcgStaticAsync<T>(
+    public static async IAsyncEnumerable<NatsPcgMsg<T>> ConsumePcgStaticAsync<T>(
         this INatsJSContext js,
         string streamName,
         string consumerGroupName,

--- a/src/Synadia.Orbit.PCGroups/version.txt
+++ b/src/Synadia.Orbit.PCGroups/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.8
+1.0.0-preview.9


### PR DESCRIPTION
Patch release for PCGroups recreating the elastic consumer on membership change so partitions newly assigned to a member are not skipped.

* Recreate elastic PCG consumer on membership change (#73)