### PR TITLE
Add docs.nats.io examples to main

### DIFF
--- a/tools/DocsExamples/ExampleAtomicBatchDoc.cs
+++ b/tools/DocsExamples/ExampleAtomicBatchDoc.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+#pragma warning disable
+
+// dotnet add package nats.net
+// dotnet add package Synadia.Orbit.JetStream.Publisher --prerelease
+using NATS.Client.JetStream.Models;
+using NATS.Net;
+using Synadia.Orbit.JetStream.Publisher;
+
+namespace DocsExamples;
+
+public class ExampleAtomicBatchDoc
+{
+    public static async Task Run()
+    {
+        await using var client = new NatsClient();
+        var js = client.CreateJetStreamContext();
+
+        // Atomic batches need a stream that opts in with AllowAtomicPublish.
+        await js.CreateStreamAsync(new StreamConfig("ORDERS", ["orders.>"])
+        {
+            AllowAtomicPublish = true,
+        });
+
+        // NATS-DOC-START
+        await using var batch = new NatsJSBatchPublisher(js);
+
+        // Three line items of one order. They all land, or none do.
+        await batch.AddAsync("orders.created", "{\"sku\":\"COFFEE-1KG\",\"qty\":2}");
+        await batch.AddAsync("orders.created", "{\"sku\":\"FILTER-100\",\"qty\":1}");
+
+        // The final item commits the batch and returns one ack for the whole order.
+        NatsJSBatchAck ack = await batch.CommitAsync("orders.created", "{\"sku\":\"MUG-350ML\",\"qty\":4}");
+
+        Console.WriteLine($"Committed batch {ack.BatchId}: {ack.BatchSize} messages into {ack.Stream}");
+        // NATS-DOC-END
+    }
+}

--- a/tools/DocsExamples/ExampleLearnJetStreamGetDirectBatchGet.cs
+++ b/tools/DocsExamples/ExampleLearnJetStreamGetDirectBatchGet.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+#pragma warning disable
+
+// dotnet add package nats.net
+// dotnet add package Synadia.Orbit.JetStream.Extensions --prerelease
+using NATS.Client.Core;
+using NATS.Client.JetStream.Models;
+using NATS.Net;
+using Synadia.Orbit.JetStream.Extensions;
+using Synadia.Orbit.JetStream.Extensions.Models;
+
+namespace DocsExamples;
+
+public class ExampleLearnJetStreamGetDirectBatchGet
+{
+    public static async Task Run()
+    {
+        var url = Environment.GetEnvironmentVariable("NATS_URL") ?? "nats://localhost:4222";
+        await using var client = new NatsClient(url);
+        var js = client.CreateJetStreamContext();
+
+        // Batch direct get needs a stream with direct access enabled.
+        await js.CreateStreamAsync(new StreamConfig("ORDERS", ["orders.>"])
+        {
+            AllowDirect = true,
+        });
+
+        await js.PublishAsync("orders.created", "{\"sku\":\"COFFEE-1KG\",\"qty\":2}");
+        await js.PublishAsync("orders.shipped", "{\"sku\":\"COFFEE-1KG\",\"qty\":2}");
+        await js.PublishAsync("orders.created", "{\"sku\":\"FILTER-100\",\"qty\":1}");
+
+        // NATS-DOC-START
+        // Fetch up to three messages starting at stream sequence 1, in one request.
+        var request = new StreamMsgBatchGetRequest
+        {
+            Seq = 1,
+            Batch = 3,
+        };
+
+        // The server streams the messages back in sequence order.
+        await foreach (NatsMsg<string> msg in js.GetBatchDirectAsync<string>("ORDERS", request))
+        {
+            // On a direct get the stream sequence and original subject come back in
+            // headers, not in msg.Subject (which is the reply subject).
+            msg.Headers!.TryGetValue("Nats-Sequence", out var sequence);
+            msg.Headers!.TryGetValue("Nats-Subject", out var subject);
+
+            Console.WriteLine($"seq {sequence}: {subject}");
+        }
+        // NATS-DOC-END
+    }
+}


### PR DESCRIPTION
Moves the two documentation examples from the `jetstream-docs` branch into `tools/DocsExamples/` on main (`ExampleAtomicBatchDoc.cs`, `ExampleLearnJetStreamGetDirectBatchGet.cs`; additive only — the csproj auto-globs and is already in `orbit.net.slnx`).

Why: the new docs.nats.io build fetches these snippets at build time; on main, `test.yml`'s `dotnet build` covers them automatically. Verified locally: project builds with 0 errors.

Note: please keep the `jetstream-docs` branch until the docs repo's fetch config is switched to `main` (follow-up PR there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)