### PR TITLE
Add Nats-Schedule-Rollup to message schedules

### DIFF
--- a/src/Synadia.Orbit.JetStream.Extensions/Models/NatsMsgSchedule.cs
+++ b/src/Synadia.Orbit.JetStream.Extensions/Models/NatsMsgSchedule.cs
@@ -176,7 +176,7 @@ public record NatsMsgSchedule
     /// When set, the fired message carries <c>Nats-Rollup: sub</c>, so it replaces all prior
     /// messages on <see cref="Target"/> and the target keeps only the latest firing.
     /// The stream must allow rollups, which it always does when it allows schedules: the server
-    /// enables <c>AllowRollup</c> and clears <c>DenyPurge</c> whenever <c>AllowMsgSchedules</c>
+    /// enables <c>AllowRollupHdrs</c> and clears <c>DenyPurge</c> whenever <c>AllowMsgSchedules</c>
     /// is set, and rejects the combination outright in pedantic mode.
     /// </remarks>
     public bool RollupSubject { get; init; }

--- a/src/Synadia.Orbit.JetStream.Extensions/Models/NatsMsgSchedule.cs
+++ b/src/Synadia.Orbit.JetStream.Extensions/Models/NatsMsgSchedule.cs
@@ -27,6 +27,7 @@ public record NatsMsgSchedule
     private const string NatsScheduleSourceHeader = "Nats-Schedule-Source";
     private const string NatsScheduleTtlHeader = "Nats-Schedule-TTL";
     private const string NatsScheduleTimeZoneHeader = "Nats-Schedule-Time-Zone";
+    private const string NatsScheduleRollupHeader = "Nats-Schedule-Rollup";
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NatsMsgSchedule"/> class with a one-time <c>@at</c> schedule.
@@ -168,6 +169,19 @@ public record NatsMsgSchedule
     public string? TimeZone { get; init; }
 
     /// <summary>
+    /// Gets a value indicating whether the message produced when the schedule fires rolls up
+    /// the target subject. Requires NATS Server 2.14 or later.
+    /// </summary>
+    /// <remarks>
+    /// When set, the fired message carries <c>Nats-Rollup: sub</c>, so it replaces all prior
+    /// messages on <see cref="Target"/> and the target keeps only the latest firing.
+    /// The stream must allow rollups, which it always does when it allows schedules: the server
+    /// enables <c>AllowRollup</c> and clears <c>DenyPurge</c> whenever <c>AllowMsgSchedules</c>
+    /// is set, and rejects the combination outright in pedantic mode.
+    /// </remarks>
+    public bool RollupSubject { get; init; }
+
+    /// <summary>
     /// Creates a schedule from a cron expression. Requires NATS Server 2.14 or later.
     /// </summary>
     /// <param name="cron">A 6-field cron expression (seconds minutes hours day-of-month month day-of-week).
@@ -250,6 +264,11 @@ public record NatsMsgSchedule
             }
 
             headers[NatsScheduleTimeZoneHeader] = timeZone;
+        }
+
+        if (RollupSubject)
+        {
+            headers[NatsScheduleRollupHeader] = "sub";
         }
 
         if (Ttl is { } ttl)

--- a/src/Synadia.Orbit.JetStream.Extensions/PACKAGE.md
+++ b/src/Synadia.Orbit.JetStream.Extensions/PACKAGE.md
@@ -56,6 +56,7 @@ for the full specification. The stream must have `AllowMsgSchedules = true`.
 | Data sampling | `NatsMsgSchedule(TimeSpan, target) { Source = ... }` | set | 2.14+ |
 | Cron schedule | `NatsMsgSchedule.Cron("0 0 * * * *", target)` | null | 2.14+ |
 | Predefined schedule | `NatsMsgSchedule.Hourly(target)` etc. | null | 2.14+ |
+| Latest-value target | `NatsMsgSchedule(TimeSpan, target) { RollupSubject = true }` | null | 2.14+ |
 
 ### Delayed Publish (NATS Server 2.12+)
 
@@ -181,6 +182,23 @@ Accepted `TimeZone` values: an IANA name (`America/New_York`, `Europe/Amsterdam`
 not accepted. The server resolves IANA names against its host's tzdata, so operators must keep
 tzdata installed and current. Setting `TimeZone` on an `@at` or `@every` schedule throws on
 `ToHeaders()`.
+
+### Rollup (NATS Server 2.14+)
+
+Set `RollupSubject` to make each fired message replace all prior messages on the target subject,
+so the target keeps only the latest firing:
+
+```csharp
+var schedule = new NatsMsgSchedule(TimeSpan.FromMinutes(1), "sensors.latest")
+{
+    Source = "sensors.raw",
+    RollupSubject = true,
+};
+```
+
+Rollups have to be allowed on the stream, which they always are when schedules are: the server
+sets `AllowRollupHdrs` and clears `DenyPurge` whenever `AllowMsgSchedules` is set, and rejects the
+combination outright in pedantic mode.
 
 ### TTL Options
 

--- a/tests/Synadia.Orbit.JetStream.Extensions.Test/SchedulingExtensionsTest.cs
+++ b/tests/Synadia.Orbit.JetStream.Extensions.Test/SchedulingExtensionsTest.cs
@@ -794,6 +794,158 @@ public class SchedulingExtensionsTest
         Assert.False(msg.Headers.ContainsKey("Nats-Schedule-Source"));
     }
 
+    [Fact]
+    public void NatsMsgSchedule_ToHeaders_sets_rollup_header()
+    {
+        var at = new NatsMsgSchedule(DateTimeOffset.UtcNow.AddMinutes(5), "events.target") { RollupSubject = true };
+        var every = new NatsMsgSchedule(TimeSpan.FromMinutes(5), "events.target") { RollupSubject = true };
+        var raw = new NatsMsgSchedule("@hourly", "events.target") { RollupSubject = true };
+        var cron = NatsMsgSchedule.Cron("0 0 * * * *", "events.target") with { RollupSubject = true };
+
+        Assert.Equal("sub", at.ToHeaders()["Nats-Schedule-Rollup"]);
+        Assert.Equal("sub", every.ToHeaders()["Nats-Schedule-Rollup"]);
+        Assert.Equal("sub", raw.ToHeaders()["Nats-Schedule-Rollup"]);
+        Assert.Equal("sub", cron.ToHeaders()["Nats-Schedule-Rollup"]);
+    }
+
+    [Fact]
+    public void NatsMsgSchedule_ToHeaders_omits_rollup_header_by_default()
+    {
+        var at = new NatsMsgSchedule(DateTimeOffset.UtcNow.AddMinutes(5), "events.target");
+        var every = new NatsMsgSchedule(TimeSpan.FromMinutes(5), "events.target");
+        var cron = NatsMsgSchedule.Cron("0 0 * * * *", "events.target");
+
+        Assert.False(at.ToHeaders().ContainsKey("Nats-Schedule-Rollup"));
+        Assert.False(every.ToHeaders().ContainsKey("Nats-Schedule-Rollup"));
+        Assert.False(cron.ToHeaders().ContainsKey("Nats-Schedule-Rollup"));
+    }
+
+    [Fact]
+    public async Task Schedule_rollup_should_replace_previous_target_messages()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectRetryAsync();
+
+        if (!connection.HasMinServerVersion(2, 14))
+        {
+            _output.WriteLine($"Skipping test - server version {connection.ServerInfo?.Version} does not support schedule rollup (requires 2.14+)");
+            return;
+        }
+
+        INatsJSContext js = connection.CreateJetStreamContext();
+        string prefix = _server.GetNextId();
+
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        var streamConfig = new StreamConfig($"{prefix}s1", [$"{prefix}foo.*"])
+        {
+            AllowMsgSchedules = true,
+            AllowRollupHdrs = true,
+            AllowDirect = true,
+        };
+
+        await js.CreateStreamAsync(streamConfig, ct);
+
+        // seq 1: a message on the target subject that the first firing should roll up.
+        var previous = await js.PublishAsync($"{prefix}foo.publish", "previous", cancellationToken: ct);
+        previous.EnsureSuccess();
+
+        // seq 2: the schedule itself, firing every second.
+        var schedule = new NatsMsgSchedule(TimeSpan.FromSeconds(1), $"{prefix}foo.publish")
+        {
+            RollupSubject = true,
+        };
+
+        var ack = await js.PublishScheduledAsync(
+            $"{prefix}foo.schedule",
+            "rolled-up",
+            schedule,
+            cancellationToken: ct);
+
+        ack.EnsureSuccess();
+
+        var stream = await js.GetStreamAsync($"{prefix}s1", cancellationToken: ct);
+
+        // seq 3 and 4 are two firings. After the second, the stream holds only the
+        // schedule and the last fired message: the rollup purged seq 1 and seq 3.
+        await WaitUntilAsync(
+            async () =>
+            {
+                await stream.RefreshAsync(ct).ConfigureAwait(false);
+                return stream.Info.State.LastSeq >= 4;
+            },
+            TimeSpan.FromSeconds(10),
+            ct);
+
+        Assert.Equal(2, stream.Info.State.Messages);
+
+        var msg = await stream.GetDirectAsync<string>(
+            new StreamMsgGetRequest { LastBySubj = $"{prefix}foo.publish" },
+            cancellationToken: ct);
+
+        Assert.Equal("rolled-up", msg.Data);
+    }
+
+    [Fact]
+    public async Task Schedule_rollup_works_without_setting_allow_rollup()
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await connection.ConnectRetryAsync();
+
+        if (!connection.HasMinServerVersion(2, 14))
+        {
+            _output.WriteLine($"Skipping test - server version {connection.ServerInfo?.Version} does not support schedule rollup (requires 2.14+)");
+            return;
+        }
+
+        INatsJSContext js = connection.CreateJetStreamContext();
+        string prefix = _server.GetNextId();
+
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        var streamConfig = new StreamConfig($"{prefix}s1", [$"{prefix}foo.*"])
+        {
+            AllowMsgSchedules = true,
+            AllowDirect = true,
+        };
+
+        // AllowRollupHdrs is left off: the server turns it on because schedules are enabled,
+        // so a schedules stream can always carry a rollup.
+        var created = await js.CreateStreamAsync(streamConfig, ct);
+        Assert.True(created.Info.Config.AllowRollupHdrs);
+        Assert.False(created.Info.Config.DenyPurge);
+
+        var previous = await js.PublishAsync($"{prefix}foo.publish", "previous", cancellationToken: ct);
+        previous.EnsureSuccess();
+
+        var schedule = new NatsMsgSchedule(TimeSpan.FromSeconds(1), $"{prefix}foo.publish")
+        {
+            RollupSubject = true,
+        };
+
+        var ack = await js.PublishScheduledAsync(
+            $"{prefix}foo.schedule",
+            "rolled-up",
+            schedule,
+            cancellationToken: ct);
+
+        ack.EnsureSuccess();
+
+        await Task.Delay(TimeSpan.FromSeconds(3), ct);
+
+        var stream = await js.GetStreamAsync($"{prefix}s1", cancellationToken: ct);
+        await stream.RefreshAsync(ct);
+
+        Assert.True(stream.Info.State.LastSeq >= 4, $"expected at least two firings, LastSeq={stream.Info.State.LastSeq}");
+        Assert.Equal(2, stream.Info.State.Messages);
+
+        var msg = await stream.GetDirectAsync<string>(
+            new StreamMsgGetRequest { LastBySubj = $"{prefix}foo.publish" },
+            cancellationToken: ct);
+
+        Assert.Equal("rolled-up", msg.Data);
+    }
+
     private static async Task WaitUntilAsync(Func<Task<bool>> condition, TimeSpan timeout, CancellationToken ct)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);

--- a/tests/Synadia.Orbit.JetStream.Extensions.Test/SchedulingExtensionsTest.cs
+++ b/tests/Synadia.Orbit.JetStream.Extensions.Test/SchedulingExtensionsTest.cs
@@ -931,12 +931,16 @@ public class SchedulingExtensionsTest
 
         ack.EnsureSuccess();
 
-        await Task.Delay(TimeSpan.FromSeconds(3), ct);
-
         var stream = await js.GetStreamAsync($"{prefix}s1", cancellationToken: ct);
-        await stream.RefreshAsync(ct);
+        await WaitUntilAsync(
+            async () =>
+            {
+                await stream.RefreshAsync(ct).ConfigureAwait(false);
+                return stream.Info.State.LastSeq >= 4;
+            },
+            TimeSpan.FromSeconds(10),
+            ct);
 
-        Assert.True(stream.Info.State.LastSeq >= 4, $"expected at least two firings, LastSeq={stream.Info.State.LastSeq}");
         Assert.Equal(2, stream.Info.State.Messages);
 
         var msg = await stream.GetDirectAsync<string>(


### PR DESCRIPTION
Server 2.14 lets a message schedule mark each fired message as a subject rollup, so the target subject keeps only the latest firing. Modelled as a bool because the server accepts exactly one value. Rollups must be allowed on the stream, which they always are when schedules are: the server enables AllowRollup and clears DenyPurge whenever AllowMsgSchedules is set, and rejects the combination in pedantic mode.