### PR TITLE
Release 1.0.0-preview.6

### DIFF
--- a/src/Synadia.Orbit.JetStream.Extensions/version.txt
+++ b/src/Synadia.Orbit.JetStream.Extensions/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.5
+1.0.0-preview.6


### PR DESCRIPTION
Preview release of JetStream.Extensions adding `Nats-Schedule-Rollup` support to message schedules.

* Add Nats-Schedule-Rollup to message schedules (#77)